### PR TITLE
Native octagon domain + simple Japron wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ target.eclipse/
 
 # intellij idea
 .idea/
+
+# ensime
+.ensime
+.ensime_cache/

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,27 @@ pplJar in ThisBuild := {
     val PPLPathName = scala.sys.process.Process("ppl-config -l").lineStream.head+"/ppl/ppl_java.jar"
     if (file(PPLPathName).exists) Some(PPLPathName) else None
   } catch {
-    case _ : Exception => None 
+    case _ : Exception => None
+  }
+}
+
+apronJar in ThisBuild := {
+  try {
+    val ApronPathName = "/usr/share/java/apron.jar"
+    // TODO Parametrize
+    if (file(ApronPathName).exists) Some(ApronPathName) else None
+  } catch {
+    case _ : Exception => None
+  }
+}
+
+gmpJar in ThisBuild := {
+  try {
+    val GMPPathName = "/usr/share/java/gmp.jar"
+    // TODO Parametrize
+    if (file(GMPPathName).exists) Some(GMPPathName) else None
+  } catch {
+    case _ : Exception => None
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -97,3 +97,7 @@ scmInfo in ThisBuild := Some(ScmInfo(
 ))
 
 libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
+
+// Following line is workaround for https://github.com/sbt/sbt-native-packager/issues/1063#issuecomment-343836338
+updateConfiguration in updateSbtClassifiers := (updateConfiguration in updateSbtClassifiers).value.withMissingOk(true)
+

--- a/build.sbt
+++ b/build.sbt
@@ -95,3 +95,5 @@ scmInfo in ThisBuild := Some(ScmInfo(
   "scm:git:https://github.com/jandom-devel/Jandom.git",
   Some("scm:git:https://github.com/jandom-devel/Jandom.git")
 ))
+
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -17,13 +17,23 @@ libraryDependencies ++= Seq(
   "ca.mcgill.sable" % "soot" %"3.0.0-SNAPSHOT"
 )
 
+//*** Add PPL, Apron, GMP jars
+
+unmanagedJars in Compile ++= (pplJar.value map file).toSeq
+unmanagedJars in Compile ++= (apronJar.value map file).toSeq
+unmanagedJars in Compile ++= (gmpJar.value map file).toSeq
+
 //*** Additional source directories for PPL
 
 unmanagedSourceDirectories in Compile ++= (pplJar.value map { _ => (sourceDirectory in Compile).value / "ppl" }).toSeq
 
 unmanagedSourceDirectories in Test ++= (pplJar.value map { _ => (sourceDirectory in Test).value / "ppl" }).toSeq
 
-unmanagedJars in Compile ++= (pplJar.value map file).toSeq
+//*** Additional source directories for Apron
+
+unmanagedSourceDirectories in Compile ++= (apronJar.value map { _ => (sourceDirectory in Compile).value / "apron" }).toSeq
+
+unmanagedSourceDirectories in Test ++= (apronJar.value map { _ => (sourceDirectory in Test).value / "apron" }).toSeq
 
 //*** BuildInfo plugin
 

--- a/core/src/main/apron/it/unich/jandom/domains/numerical/apron/ApronDomain.scala
+++ b/core/src/main/apron/it/unich/jandom/domains/numerical/apron/ApronDomain.scala
@@ -1,0 +1,32 @@
+package it.unich.jandom.domains.numerical.apron
+import it.unich.jandom.domains.WideningDescription
+import it.unich.jandom.domains.numerical.NumericalDomain
+import it.unich.jandom.domains.numerical.BoxGenericDomain
+import it.unich.jandom.domains.numerical.BoxRationalDomain
+import it.unich.jandom.utils.numberext.RationalExt
+import apron._
+
+class ApronDomain[A <: Manager, N <: ApronNumericalDomainAdapter[A]](val manager : A, val boxDomain : BoxGenericDomain[RationalExt], val apronnum : N) extends NumericalDomain {
+
+  type Property = ApronProperty[A, N]
+
+  def top(n: Int): Property = new ApronProperty(this, apronnum.top(n))(apronnum)
+  def bottom(n: Int): Property = new ApronProperty(this, apronnum.bottom(n))(apronnum)
+
+  val widenings = Seq(WideningDescription.default[Property])
+}
+
+object ApronIntOctagonDomain {
+  val octman : Octagon = new Octagon()
+  val boxDomain = BoxRationalDomain()
+  val apronint : ApronIntAdapter[Octagon] = new ApronIntAdapter(octman)
+  def apply() = new ApronDomain[Octagon, ApronIntAdapter[Octagon]](octman, boxDomain, apronint)
+}
+
+
+object ApronRealOctagonDomain {
+  val octman : Octagon = new Octagon()
+  val boxDomain = BoxRationalDomain()
+  val apronreal : ApronRealAdapter[Octagon] = new ApronRealAdapter(octman)
+  def apply() = new ApronDomain[Octagon, ApronRealAdapter[Octagon]](octman, boxDomain, apronreal)
+}

--- a/core/src/main/apron/it/unich/jandom/domains/numerical/apron/ApronProperty.scala
+++ b/core/src/main/apron/it/unich/jandom/domains/numerical/apron/ApronProperty.scala
@@ -1,0 +1,164 @@
+package it.unich.jandom.domains.numerical.apron
+
+import it.unich.jandom.domains.numerical.LinearForm
+import it.unich.jandom.domains.numerical.NumericalProperty
+import it.unich.jandom.utils.numberext.RationalExt
+import it.unich.jandom.domains.numerical.Inequalities
+import apron._
+
+trait ApronNumericalDomainAdapter [A <: Manager] {
+  def top(n : Int) : Abstract0
+  def bottom(n : Int) : Abstract0
+  def dimension(obj : Abstract0) : Int
+}
+
+class ApronIntAdapter[A <: Manager](man : A) extends ApronNumericalDomainAdapter[A] {
+  def top(n : Int) = new Abstract0(man, n, 0)
+  def bottom(n : Int) = new Abstract0(man, n, 0, true)
+  def dimension(obj : Abstract0) : Int = obj.getDimension(man).intDim
+}
+
+class ApronRealAdapter[A <: Manager](man : A) extends ApronNumericalDomainAdapter[A] {
+  def top(n : Int) = new Abstract0(man, 0, n)
+  def bottom(n : Int) = new Abstract0(man, 0, n, true)
+  def dimension(obj : Abstract0) : Int = obj.getDimension(man).realDim
+}
+
+
+class ApronProperty[A <: Manager, F <: ApronNumericalDomainAdapter[A]] (val domain: ApronDomain[A, F], val obj : Abstract0)(implicit val apronnum : F)
+    extends NumericalProperty[ApronProperty[A, F]] {
+  private val kDebugConstr : Boolean = true  // TODO: Move elsewhere or add option to GUI
+  type Domain = ApronDomain[A, F]
+  type Property = ApronProperty[A, F]
+
+  def widening(that: Property): Property = if (true) this.top else {
+    val res = new Property(this.domain, this.obj.widening(this.domain.manager, that.obj))
+    assert(res.obj.getDimension(this.domain.manager) == this.obj.getDimension(this.domain.manager))
+    res
+  }
+
+  def narrowing(that: Property): Property = this
+  // after PPLProperty.narrowing; Japron doesn't expose narrowing
+  // TODO: Come up with something better or patch Japron
+
+  def union(that: Property): Property = {
+    assert(that.obj.getDimension(this.domain.manager) == this.obj.getDimension(this.domain.manager))
+    val res = new Property(this.domain, that.obj.joinCopy(this.domain.manager, this.obj))
+    assert(res.obj.getDimension(this.domain.manager) == this.obj.getDimension(this.domain.manager))
+    res
+  }
+
+  def intersection(that: Property): Property = {
+    val res = new Property(this.domain, that.obj.meetCopy(this.domain.manager, this.obj))
+    assert(res.obj.getDimension(this.domain.manager) == this.obj.getDimension(this.domain.manager))
+    res
+  }
+
+  def nonDeterministicAssignment(n: Int): Property = {
+    require(n < dimension && n >= 0)
+    if (isEmpty)
+      this
+    else
+      new Property(this.domain, this.obj.forgetCopy(this.domain.manager, Array(n), false))
+  }
+
+  // Abstract assignment (Mine sects. 4.2, 4.4)
+  def linearAssignment(n: Int, lf: LinearForm): Property = {
+    assert(n <= dimension)
+    new Property(this.domain, obj.assignCopy(this.domain.manager, n, SpireGmpUtils.lfToLinexpr(lf), null))
+  }
+
+  // Abstract test (Mine sect. 4.5)
+  def linearInequality(lf: LinearForm): Property = {
+    new ApronProperty(this.domain, obj.meetCopy(this.domain.manager, SpireGmpUtils.lfToLincons(lf)))
+  }
+
+  def linearDisequality(lf: LinearForm): Property = ??? // TODO
+
+  def toInterval : domain.boxDomain.Property =
+  {
+    val box = this.obj.toBox(this.domain.manager)
+    val inf  = box.map(x => SpireGmpUtils.scalarToRatExt(x.inf()))
+    val sup  = box.map(x => SpireGmpUtils.scalarToRatExt(x.sup()))
+    val isNotEmpty = (inf zip sup).foldLeft(true)((z,i) => z & (!(i._1.isPosInfinity) && !(i._2.isNegInfinity)))
+    if (isNotEmpty)
+      domain.boxDomain.makeBox(inf, sup, false)
+    else {
+      val pairs = Array.fill(inf.size)((RationalExt.PositiveInfinity, RationalExt.NegativeInfinity))
+      domain.boxDomain.makeBox(pairs.unzip._1, pairs.unzip._2, true)
+    }
+  }
+
+  def minimize(lf: LinearForm) = ??? // TODO
+
+  def maximize(lf: LinearForm) = ??? // TODO
+
+  def frequency(lf: LinearForm) = ??? // TODO
+
+  def constraints : Seq[LinearForm] = {
+    this.obj.toLincons(this.domain.manager).toSeq.flatMap(SpireGmpUtils.linconsToLf(_)).map(_.padded(dimension+1))
+  }
+
+  def isPolyhedral = ??? // TODO
+
+  def addVariable = ??? // TODO
+
+  def delVariable(n: Int) = ??? // TODO
+
+  def mapVariables(rho: Seq[Int]) = ??? // TODO
+
+  def dimension: Int = apronnum.dimension(this.obj)
+
+  def isEmpty = isBottom
+
+  def isTop = this.obj.isTop(this.domain.manager)
+
+  def isBottom = this.obj.isBottom(this.domain.manager)
+
+  def bottom = domain.bottom(this.dimension)
+
+  def top = domain.top(this.dimension)
+
+  // Copypasted from PPL
+  def tryCompareTo[B >: Property](other: B)(implicit arg0: (B) => PartiallyOrdered[B]): Option[Int] =
+    other match {
+      case other: ApronProperty[_, _] => {
+        assert (obj.getClass == other.obj.getClass)
+        if (obj equals other.obj)
+          Option(0)
+        else if (other.obj.isIncluded(this.domain.manager, this.obj) && (this.obj.isIncluded(this.domain.manager, other.obj)))
+          Option(0)
+        else if (other.obj.isIncluded(this.domain.manager, this.obj))
+          Option(1)
+        else if (this.obj.isIncluded(this.domain.manager, other.obj))
+          Option(-1)
+        else {
+          assert(false)
+          Option.empty
+        }
+      }
+      case _ => {
+        assert(false)
+        Option.empty
+      }
+    }
+
+  override def hashCode: Int = obj.hashCode
+
+  def mkString(vars: Seq[String]): String = {
+    if (isTop) {
+      "[ T ]"
+    } else if (isBottom) {
+      "[ _|_ ]"
+    } else {
+      "[ " +
+      Inequalities.constraintsToInequalities(constraints).map(_.mkString(vars)).mkString("; ")
+    } +
+      (if (!kDebugConstr) {
+      " ]"
+    } else {
+      " ]        //" +
+      constraints
+    })
+  }
+}

--- a/core/src/main/apron/it/unich/jandom/domains/numerical/apron/SpireGmpUtils.scala
+++ b/core/src/main/apron/it/unich/jandom/domains/numerical/apron/SpireGmpUtils.scala
@@ -1,0 +1,136 @@
+package it.unich.jandom.domains.numerical.apron
+import it.unich.jandom.domains.numerical.LinearForm
+import it.unich.jandom.utils.numberext.RationalExt
+import apron._
+import gmp.Mpq
+import spire.math.Rational
+
+object SpireGmpUtils {
+  def ratToMpq(x : Rational) : Mpq = {
+    assert(x.denominatorAsLong != 0)
+    val num = java.math.BigInteger.valueOf(x.numeratorAsLong)
+    val den = java.math.BigInteger.valueOf(x.denominatorAsLong)
+    assert(den != 0)
+    new Mpq(num, den)
+  }
+
+  def scalarToRatExt(s : Scalar) : RationalExt = {
+    if (s.isInfty != 0) {
+      if (s.isInfty == -1) {
+         RationalExt.NegativeInfinity
+      } else if (s.isInfty == 1) {
+         RationalExt.PositiveInfinity
+      } else {
+        ???
+      }
+    } else if (s.isZero) {
+      RationalExt.zero
+    } else {
+      assert(s.isInfty == 0 & s.isZero == false)
+      val mpq : Mpq = new Mpq(1,1)
+      val res = s.toMpq(mpq, 0) // has side effects on 1st arg
+      assert(res == 0)
+      assert(mpq.getDen.bigIntegerValue != 0)
+      RationalExt(mpqToRat(mpq))
+    }
+  }
+
+  def ratExtToScalar(r : RationalExt) : Scalar = {
+    if (r.isPosInfinity) {
+      val s = Scalar.create()
+      s.setInfty(1)
+      s
+    }
+    else if (r.isNegInfinity) {
+      val s = Scalar.create()
+      s.setInfty(-1)
+      s
+    } else if (r.isZero) {
+      val s = Scalar.create()
+      s.set(0)
+      s
+    } else {
+      new MpqScalar(ratToMpq(r.value))
+    }
+  }
+
+  def mpqToRat(x : Mpq) : Rational = {
+    val num = x.getNum.bigIntegerValue
+    val den = x.getDen.bigIntegerValue
+    assert(den != 0)
+    Rational(num, den)
+  }
+
+
+  def unsafeCoeffToRational(a : Coeff) : Rational = {
+    if (a.isZero) {
+      Rational(0)
+    } else if (a.isScalar) {
+      assert(a.inf.isInfty == 0, "Can't convert infty to Rational. Can convert infty to RationalExt, however.")
+      val re = scalarToRatExt(a.inf) // Scalar.inf = itself
+      assert(!re.isInfinity)
+      re.value
+    } else {
+      ???
+    }
+  }
+
+  def coeffToRationalExt(a : Coeff) : RationalExt = {
+    if (a.isScalar) {
+      scalarToRatExt(a.inf)
+    } else {
+      ???
+    }
+  }
+
+  def rationalToCoeff(a : Rational) : Coeff = {
+    new MpqScalar(ratToMpq(a))
+  }
+
+  def lfToLincons(lf : LinearForm) : Lincons0 = {
+    val le = SpireGmpUtils.lfToLinexpr(lf * -1)
+    new Lincons0(Lincons0.SUPEQ, le) // TODO: Triple check sign!!!
+  }
+
+  def linconsToLf(lc : Lincons0) : Seq[LinearForm] = {
+    assert(lc.scalar == null) // Don't know how to handle congruences/don't care
+    lc.kind match {
+      case Lincons0.SUPEQ => Seq(SpireGmpUtils.linexprToLf(lc.expr) * -1)
+      case Lincons0.EQ => {
+        val lf = SpireGmpUtils.linexprToLf(lc.expr)
+        val lf2 = lf * -1
+        Seq(lf, lf2)
+      }
+      case _ => ??? // Don't know/don't care
+    }
+  }
+
+  def lfToLinexpr(a : LinearForm) : Linexpr0 = {
+    val ltrms : Array[Coeff] = a.coeffs.map(ratExtToScalar(_)).toArray
+    assert(ltrms.length > 0)
+    new Linexpr0(ltrms.tail, ltrms.head)
+  }
+
+  def linexprToLf(a : Linexpr0) : LinearForm = {
+    /*
+     *  This check can be removed if Linexpr0.getCoeffs is patched with
+     *
+     *  if (l.length == 0) {
+     *     Coeff[] c = new Coeff[0];
+     *     return c;
+     *  } else {
+     *     ...
+     *
+     */
+    val coeffs = if (a.getSize() == 0)
+      Array[Rational]()
+    else
+      (a.getCoeffs.map((x) => unsafeCoeffToRational(x)).toArray)
+    val cst = unsafeCoeffToRational(a.getCst)
+    val ltrms = cst +: coeffs
+    assert(ltrms.length > 0)
+
+    LinearForm(ltrms.toList : _*)
+  }
+
+}

--- a/core/src/main/apron/it/unich/jandom/ui/ApronUIInitializer.scala
+++ b/core/src/main/apron/it/unich/jandom/ui/ApronUIInitializer.scala
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2013, 2016 Gianluca Amato <gianluca.amato@unich.it>
+ *
+ * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+ * JANDOM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JANDOM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty ofa
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package it.unich.jandom.ui
+
+import it.unich.jandom.domains.numerical.apron.ApronIntOctagonDomain
+
+private[ui] object ApronUIInitializer {
+    NumericalDomains.values ++= Seq(
+    ParameterValue(ApronIntOctagonDomain(), "Apron Octagon Domain", "foo")
+  )
+}

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/BoxDoubleDomain.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/BoxDoubleDomain.scala
@@ -37,7 +37,10 @@ import spire.math.Rational
  * @param overReals is true if the domain is correct w.r.t. real arithmetic, otherwise it is correct w.r.t.
  * double arithmetics.
  */
-class BoxDoubleDomain(val overReals: Boolean) extends NumericalDomain {
+class BoxDoubleDomain(val overReals: Boolean) extends BoxGenericDomain[Double] {
+
+  def makeBox(low: Array[Double], high: Array[Double], isEmpty: Boolean) = new Property(low, high, isEmpty)
+
   /**
    * This is the class representing a single box.
    *

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/BoxDoubleDomain.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/BoxDoubleDomain.scala
@@ -206,7 +206,7 @@ class BoxDoubleDomain(val overReals: Boolean) extends NumericalDomain {
      * @return a tuple with two components: the first component is the least value, the second component is the greatest value
      * of the linear form over the box.
      */
-    private def linearEvaluation(lf: LinearForm): (Double, Double) = {
+    def linearEvaluation(lf: LinearForm): (Double, Double) = {
       val known = lf.known.toDouble
       val homcoeffs = lf.homcoeffs.map (_.toDouble).toArray
       linearEvaluation(known, homcoeffs)

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/BoxGenericDomain.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/BoxGenericDomain.scala
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2013, 2016 Gianluca Amato <gianluca.amato@unich.it>
+ *
+ * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+ * JANDOM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JANDOM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of a
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package it.unich.jandom.domains.numerical
+
+trait BoxGenericDomain[A]/*[DOM <: BoxGenericDomain[DOM]]*/ extends NumericalDomain {
+  type Property <: NumericalProperty[Property] {
+    def high: Array[A]
+    def low: Array[A]
+    def linearInequality(lf: LinearForm): Property
+    def linearAssignment(n: Int, lf: LinearForm): Property
+    def linearEvaluation(lf: LinearForm): (A, A)
+  }
+
+  def makeBox(low: Array[A], high: Array[A], isEmpty: Boolean): Property
+}

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/BoxRationalDomain.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/BoxRationalDomain.scala
@@ -34,7 +34,10 @@ import spire.math.Rational
  * @constructor Builds a box domain uses rational as bounds
  */
 
-class BoxRationalDomain private extends NumericalDomain {
+class BoxRationalDomain private extends BoxGenericDomain[RationalExt] {
+
+  def makeBox(low: Array[RationalExt], high: Array[RationalExt], isEmpty: Boolean) = new Property(low, high, isEmpty)
+
   /**
    * This is the class representing a single box.
    *
@@ -143,7 +146,7 @@ class BoxRationalDomain private extends NumericalDomain {
      * @return a tuple with two components: the first component is the least value, the second component is the greatest value
      * of the linear form over the box.
      */
-    private def linearEvaluation(lf: LinearForm): (RationalExt, RationalExt) = {
+    def linearEvaluation(lf: LinearForm): (RationalExt, RationalExt) = {
       require(lf.dimension <= dimension)
       var newlow = RationalExt(lf.known)
       var newhigh = RationalExt(lf.known)

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/DenseLinearForm.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/DenseLinearForm.scala
@@ -43,16 +43,6 @@ class DenseLinearForm[T](val coeffs: Seq[Rational]) extends LinearForm {
 
   def pairs = for { (ci, i) <- homcoeffs.zipWithIndex ; if ! ci.isZero } yield (i,ci)
 
-  /**
-   * Equality between linear forms. Two linear forms are equal if their coefficients are the same and
-   * are defined over the same environment.
-   */
-  override def equals(that: Any): Boolean = that match {
-    case that: LinearForm =>
-      (coeffs zip that.coeffs) forall (tuple => tuple._1 == tuple._2)
-    case _ => false
-  }
-
   def unary_-(): LinearForm = new DenseLinearForm(coeffs map (x => -x))
 
   def +(that: LinearForm): LinearForm = {

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/LinearForm.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/LinearForm.scala
@@ -170,3 +170,259 @@ object LinearForm {
    */
   implicit def c[T <% Rational](known: T): LinearForm = DenseLinearForm(List(known))
 }
+
+/**
+  * Inequalities are for human-readable pretty-printing of constraints
+  */
+object Inequalities {
+
+  trait Inequality {
+    def mkString(vars: Seq[String]) : String
+    def contains(x: Rational) : Boolean
+  }
+
+  def homCoeffToString (homcoeffs : Seq[Rational], vars : Seq[String]) : String = {
+    homcoeffs.zip(0 to homcoeffs.length-1).map((k : (Rational, Int)) =>
+      k match { case (x,y) =>
+        if (x != 0) {
+          ((
+            if (x != 1)
+            {
+              if (x != -1)
+              { (x)+"*" }
+              else { "-" }
+            }
+            else
+            {""}
+          )+vars(y)).replace("+","")
+        }
+        else { "" }
+      }
+    ).
+      filter(_ != "").
+      mkString("+").
+      replace("+-", "-")
+  }
+
+  case class Eq(c: Rational, homcoeffs: Seq[Rational]) extends Inequality {
+    def contains(x: Rational) = x == c
+    def mkString(vars: Seq[String]) = {
+      // Rewrite eq for optimal polarity, i.e. with minimum number of -
+      val negs = (homcoeffs :+ c).filter(_ < 0).length
+      val poss = (homcoeffs :+ c).filter(_ > 0).length
+      if (negs > poss) {
+        // Too many - signs, flip
+        homCoeffToString(homcoeffs.map(_ * -1), vars)+" = "+(-c)
+      } else {
+        homCoeffToString(homcoeffs, vars)+" = "+(c)
+      }
+    }
+  }
+
+  case class Ineq(c: Rational, homcoeffs: Seq[Rational]) extends Inequality {
+    def contains(x: Rational) = x >= c
+    def mkString(vars: Seq[String]) = {
+      // Rewrite eq for optimal polarity, i.e. with minimum number of -
+      val negs = (homcoeffs :+ c).filter(_ < 0).length
+      val poss = (homcoeffs :+ c).filter(_ > 0).length
+      if (negs > poss) {
+        // Too many - signs, flip
+        homCoeffToString(homcoeffs.map(_ * -1),vars)+" <= "+(-c)
+      } else {
+        homCoeffToString(homcoeffs,vars)+" >= "+c
+      }
+    }
+  }
+
+  case class Between(bottom: Rational, top: Rational, homcoeffs: Seq[Rational]) extends Inequality {
+    assert(bottom <= top)
+    def contains(x: Rational) = bottom >= x & x >= top
+    def mkString(vars: Seq[String]) = {
+      // Rewrite eq for optimal polarity, i.e. with minimum number of -
+      val negs = (homcoeffs :+ top :+ bottom).filter(_ < 0).length
+      val poss = (homcoeffs :+ top :+ bottom).filter(_ > 0).length
+      if (negs > poss) {
+        // Too many - signs, flip
+        -top + " <= " + homCoeffToString(homcoeffs.map(_ * -1), vars)+" <= "+ -bottom
+      } else {
+        bottom + " <= " + homCoeffToString(homcoeffs, vars)+" <= " + top
+      }
+    }
+  }
+
+  def mergeIneq(i1 : Inequality, i2 : Inequality) :  Either[Inequality, (Inequality, Inequality)] = {
+    i1 match {
+      case Ineq(c1, hom1) =>
+        i2 match {
+          case Eq(c2, hom2) => {
+            if (hom1 == hom2) {
+              assert(i1.contains(c2))
+              Left(i2)
+            } else {
+              if (hom1.map(_ * -1) == hom2) {
+                assert(i2.contains(-c2))
+                Left(i2)
+              } else {
+                // Incompatible coeffs
+                Right((i1, i2))
+              }
+            }
+          }
+          case Ineq(c2, hom2) => {
+            if (hom1 == hom2) {
+              // hom1 >= c1, hom1 >= c2 => tighter bound is max(c1,c2)
+              Left(Ineq(c1.max(c2), hom1))
+            } else {
+              if (hom1.map(_ * -1) == hom2) {
+                // hom1 >= c1 => -hom1 <= -c1
+                if (c2 == -c1) {
+                  // hom2 <= c2 & hom2 >= c2 => hom2 == c2
+                  Left((Eq(c1, hom1)))
+                } else {
+                  // hom2 <= -c1 & hom2 >= c2 => c2 <= hom2 <= -c1
+                  Left(Between(c2, -c1, hom2))
+                }
+              } else {
+                // nothing to do, incompatible
+                Right((i1, i2))
+              }
+            }
+          }
+          case Between(bottom2, top2, hom2) => {
+            if (hom1 == hom2) {
+              // Compatible coeffs
+              // bottom2 <= hom1 <= top2 & hom1 >= c1 =>  max(bottom2, c1) <= hom1 <= top2
+              Left(Between(c1.max(bottom2), c1.min(top2), hom1))
+            } else {
+              if (hom1.map(_ * -1) == hom2) {
+                // hom2 <= -c1
+                // bottom2 <= hom2 <= top2 & -hom2 >= c1 =>  bottom2 <= hom2 <= min(-c1, top2)
+                Left(Between(bottom2, -c1.min(top2), hom2))
+              } else {
+                // nothing to do, incompatible
+                Right((i1, i2))
+              }
+            }
+          }
+        }
+      case Eq(c1, hom1) => {
+        i2 match {
+          case Eq(c2, hom2) => {
+            if (hom1 == hom2) {
+              assert(c1 == c2)
+              Left(i2)
+            } else {
+              if (hom1.map(_ * -1) == hom2) {
+                assert(-c1 == c2)
+                Left(i2)
+              } else {
+                // Incompatible
+                Right((i1, i2))
+              }
+            }
+          }
+          case Ineq(c2, hom2) => {
+            if (hom1 == hom2) {
+              assert(i2.contains(c1))
+              Left(i1)
+            } else {
+              if (hom1.map(_ * -1) == hom2) {
+                // hom2 >= c2 & c1 = -hom2 => hom2 - -c1
+                assert(i2.contains(-c1))
+                Left(i1)
+              } else {
+                // Incompatible, nothing to do
+                Right((i1, i2))
+              }
+            }
+          }
+          case Between(bottom2, top2, hom2) => {
+            if (hom1 == hom2) {
+              assert(i2.contains(c1))
+              Left(i1)
+            } else {
+              if (hom1.map(_ * -1) == hom2) {
+                assert(i2.contains(-c1))
+                Left(i1)
+              } else {
+                // nothing to do, incompatible
+                Right((i1, i2))
+              }
+            }
+          }
+        }
+      }
+      case Between(bottom1, top1, hom1) =>
+        i2 match {
+          case Eq(c2, hom2) => {
+            if (hom1 == hom2) {
+              assert(i1.contains(c2))
+              Left(i1)
+            } else {
+              if (hom1.map(_ * -1) == hom2) {
+                assert(i1.contains(-c2))
+                Left(i1)
+              } else {
+                // nothing to do, incompatible
+                Right((i1, i2))
+              }
+            }
+          }
+          case Ineq(c2, hom2) => {
+            if (hom1 == hom2) {
+              // bottom1 <= hom1 <= top1 & hom1 >= c2 => max(bottom1, c2) <= hom1 <= top1
+              Left(Between(bottom1.max(c2), top1, hom2))
+            } else {
+              if (hom1.map(_ * -1) == hom2) {
+                // bottom1 <= hom1 <= top1 & -hom1 >= c2 => hom1 <= - c2 => bottom1 <= hom1 <= min(-c2, top1)
+                Left(Between(bottom1, top1.min(-c2), hom1))
+              } else {
+                // nothing to do, incompatible
+                Right((i1, i2))
+              }
+            }
+          }
+          case Between(bottom2, top2, hom2) => {
+            if (hom1 == hom2) {
+              Left(Between(bottom1.max(bottom2), top1.min(top2), hom1)) // use tightest bound
+            } else {
+              if (hom1.map(_ * -1) == hom2) {
+                //   bottom1 <= hom1 <= top1
+                // & bottom2 <= -hom1 <= top2 => -top2 <= hom1 <= -bottom2
+                // => max(bottom1, -top2) <= hom1 <= min(top1, -bottom2)
+                Left(Between(bottom1.min(-top2), top1.max(-bottom2), hom1))
+              } else {
+                // nothing to do, incompatible
+                Right((i1, i2))
+              }
+            }
+          }
+        }
+    }
+  }
+
+  /**
+    * Turns a set constraints into a set of inequalities, of the form
+    *
+    *  vi + ... + vj <= c
+    *  vi + ... + vj = c
+    *  c' <= vi + ... + <= c
+    *
+    *  for human readability; inequalities have support for pretty-printing
+    */
+  def constraintsToInequalities(constraints : Seq[LinearForm]) : Seq[Inequality] = {
+    val cons : Seq[Inequality] = constraints.map((l) => Ineq(l.known, l.homcoeffs.map(_ * -1)))
+
+    cons.foldRight(Seq[Inequality]())((i : Inequality,z : Seq[Inequality]) => {
+      val foo = z.map((q : Inequality) => mergeIneq(q,i) match {
+        case Left(a:Inequality) => Left(a)
+        case Right((a,b)) => Right(q)
+      })
+
+      if(foo.map((x) => x match { case Left(_) => true case Right(_) => false }).filter((x) => x == true).length > 0)
+        foo.map((x) => x match { case Left(y) => y case Right(y) => y })
+      else
+        i +: foo.map((x) => x match { case Left(y) => y case Right(y) => y })
+    })
+  }
+}

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/LinearForm.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/LinearForm.scala
@@ -134,6 +134,13 @@ trait LinearForm {
   }
 
   override final def hashCode: Int = (coeffs).hashCode()
+
+  def padded (n : Int) : LinearForm = {
+    assert(coeffs.size <= n) // TODO: handle
+    if (coeffs.size == n)
+      this
+    else LinearForm((coeffs ++ List.fill[Rational](n - coeffs.size)(0)) : _*)
+  }
 }
 
 /**

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/LinearForm.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/LinearForm.scala
@@ -115,13 +115,25 @@ trait LinearForm {
    * @inheritdoc
    * It is equivalent to `mkString` with variable names `v0`...`vn`
    */
-  override def toString = mkString(Stream.from(0).map { "v" + _ })
+  override final def toString = mkString(Stream.from(0).map { "v" + _ })
 
   /**
    * This is used to store the PPL version of this linear form. It is declared
    * of type `AnyRef` so that it may be compiled even when PPL is not present.
    */
   var toPPL: AnyRef = null
+
+  /**
+   * Equality between linear forms. Two linear forms are equal if their coefficients are the same and
+   * are defined over the same environment.
+    */
+
+  override final def equals(that: Any): Boolean = that match {
+    case that: LinearForm => coeffs == that.coeffs
+    case _ => false
+  }
+
+  override final def hashCode: Int = (coeffs).hashCode()
 }
 
 /**

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/OctagonDomain.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/OctagonDomain.scala
@@ -2,6 +2,7 @@ package it.unich.jandom.domains.numerical
 import it.unich.jandom.domains.WideningDescription
 import it.unich.jandom.utils.dbm._
 import it.unich.jandom.domains.numerical.octagon._
+import it.unich.jandom.domains.numerical.octagon.optimized._
 import it.unich.jandom.utils.numberext.RationalExt
 import spire.math.Rational
 import scala.reflect.ClassTag
@@ -14,8 +15,8 @@ class OctagonDomain(val boxDomain : BoxGenericDomain[RationalExt]) extends Numer
   implicit val closure = new IncrementalMineFloydWarshall[RationalExt]()(ifield, factory)
   implicit val octDomain : OctagonDomain = this
   implicit val box = BoxRationalDomain()
-  def top(dim : Int) : Property = ???
-  def bottom(dim : Int): Property = ???
+  def top(dim : Int) : Property = new OctagonProperty(new CachingOctagon(Right(factory.top((OctagonDim(dim).toDBMDim)))))
+  def bottom(dim : Int): Property = new OctagonProperty(new BottomOctagon(OctagonDim(dim)))
 
   val widenings = Seq(WideningDescription.default[Property])
 

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/OctagonDomain.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/OctagonDomain.scala
@@ -1,0 +1,40 @@
+package it.unich.jandom.domains.numerical
+import it.unich.jandom.domains.WideningDescription
+import it.unich.jandom.utils.dbm._
+import it.unich.jandom.domains.numerical.octagon._
+import it.unich.jandom.utils.numberext.RationalExt
+import spire.math.Rational
+import scala.reflect.ClassTag
+
+class OctagonDomain(val boxDomain : BoxGenericDomain[RationalExt]) extends NumericalDomain {
+  type Property = OctagonProperty
+  implicit val ifield = RationalExt
+  implicit val tag = implicitly[ClassTag[RationalExt]]
+  implicit val factory = new ArrayDBMFactory()(tag, ifield)
+  implicit val closure = new IncrementalMineFloydWarshall[RationalExt]()(ifield, factory)
+  implicit val octDomain : OctagonDomain = this
+  implicit val box = BoxRationalDomain()
+  def top(dim : Int) : Property = ???
+  def bottom(dim : Int): Property = ???
+
+  val widenings = Seq(WideningDescription.default[Property])
+
+  def fromBox (b : BoxRationalDomain#Property) : OctagonProperty =
+    if (b.isEmpty)
+      bottom(b.dimension)
+    else {
+      val lower = b.low.zip(1 to b.dimension).foldRight(this.top(b.dimension))(
+        (i, z : OctagonProperty) =>
+          if (i._1.isNegInfinity) z
+          else z.linearInequality(LinearForm(Array.fill[Rational](b.dimension + 1)(0).updated(i._2, Rational(-1)).updated(0, i._1.value) : _*)))
+
+      b.high.zip(1 to b.dimension).foldRight(lower)((i, z : OctagonProperty) =>
+          if (i._1.isPosInfinity) z
+          else z.linearInequality(LinearForm(Array.fill[Rational](b.dimension + 1)(0).updated(i._2, Rational(1)).updated(0, -i._1.value) : _*)))
+    }
+}
+
+object OctagonDomain {
+  val boxDomain = BoxRationalDomain()
+  def apply() = new OctagonDomain(boxDomain)
+}

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/OctagonDomain.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/OctagonDomain.scala
@@ -4,7 +4,6 @@ import it.unich.jandom.utils.dbm._
 import it.unich.jandom.domains.numerical.octagon._
 import it.unich.jandom.domains.numerical.octagon.optimized._
 import it.unich.jandom.utils.numberext.RationalExt
-import spire.math.Rational
 import scala.reflect.ClassTag
 
 trait OctagonDomainTrait[O <: Octagon[RationalExt, O]] extends NumericalDomain {

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/Octagon.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/Octagon.scala
@@ -17,6 +17,7 @@
   */
 
 package it.unich.jandom.domains.numerical.octagon
+import it.unich.jandom.utils.dbm._
 import it.unich.jandom.utils.numberext.IField
 import math.PartiallyOrdered
 
@@ -171,6 +172,11 @@ case class VMinusIdx(i : Int) extends SignedVarIdx {
 
 case class OctagonDim(private val n : Int) {
   require(n != 0)
+  def toDBMDim : DBMDim = DBMDim(n * 2)
   def octagonDimToInt : Int = n
   def allVars : Seq[Var] = (1 to n).map(Var(_))
+}
+
+object OctagonDim {
+  def apply(d : DBMDim) : OctagonDim = OctagonDim(d.dbmDimToInt / 2)
 }

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/Octagon.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/Octagon.scala
@@ -75,6 +75,37 @@ trait Octagon[N <: IField[N], O <: Octagon[N, O]]
 
 }
 
+
+trait BottomOctagon[N <: IField[N], O <: Octagon[N, O]] {
+
+  def dimension: OctagonDim
+  def bottom : O
+
+  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : O = bottom
+  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : O = bottom
+  def test_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : O = bottom
+  def test_vj0_plus_vi0_le_c(vj0 : Var, vi0 : Var, c : N) : O = bottom
+  def test_minus_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : O = bottom
+
+  def get_ineq_vi_minus_vj_leq_c(i : SignedVarIdx, j : SignedVarIdx) : Option[N] = None
+
+  def forget(f : Var) : O = bottom
+  def assign_vj0_gets_c(j0 : Var, c : N):  O = bottom
+  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : O = bottom
+  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : O = bottom
+  def assign_vk_gets_e(k : Int) : O = bottom
+  def assign_vj0_gets_minus_vj0(j0 : Var) : O = bottom
+  def assign_vj0_gets_vi0 (j0 : Var, i0 : Var) : O = bottom
+  //////
+  def isEmpty : Boolean = true
+  def isBottom : Boolean = true
+  def isTop : Boolean = false
+  def union(that : O) = that
+  def intersection(that : O) = bottom
+  def widening(that : O) : O = that
+  def narrowing(that : O) : O = ???
+}
+
 //////////////////////
 // UTILS
 //////////////////////
@@ -127,34 +158,4 @@ case class OctagonDim(private val n : Int) {
 
 object OctagonDim {
   def apply(d : DBMDim) : OctagonDim = OctagonDim(d.dbmDimToInt / 2)
-}
-
-trait BottomOctagon[N <: IField[N], O <: Octagon[N, O]] {
-
-  def dimension: OctagonDim
-  def bottom : O
-
-  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : O = bottom
-  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : O = bottom
-  def test_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : O = bottom
-  def test_vj0_plus_vi0_le_c(vj0 : Var, vi0 : Var, c : N) : O = bottom
-  def test_minus_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : O = bottom
-
-  def get_ineq_vi_minus_vj_leq_c(i : SignedVarIdx, j : SignedVarIdx) : Option[N] = None
-
-  def forget(f : Var) : O = bottom
-  def assign_vj0_gets_c(j0 : Var, c : N):  O = bottom
-  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : O = bottom
-  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : O = bottom
-  def assign_vk_gets_e(k : Int) : O = bottom
-  def assign_vj0_gets_minus_vj0(j0 : Var) : O = bottom
-  def assign_vj0_gets_vi0 (j0 : Var, i0 : Var) : O = bottom
-  //////
-  def isEmpty : Boolean = true
-  def isBottom : Boolean = true
-  def isTop : Boolean = false
-  def union(that : O) = that
-  def intersection(that : O) = bottom
-  def widening(that : O) : O = that
-  def narrowing(that : O) : O = ???
 }

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/Octagon.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/Octagon.scala
@@ -1,0 +1,176 @@
+/**
+  * Copyright 2018 Filippo Sestini, Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty ofa
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.domains.numerical.octagon
+import it.unich.jandom.utils.numberext.IField
+import math.PartiallyOrdered
+
+
+/**
+  * The definition of an object exposing a subset of the transfer
+  * functions and attributes detailed in Mine' 2006, "The Octagon
+  * Abstract Domain".
+  *
+  * Specifically, we expose the functionality that has an intersection
+  * Jandom, so for example backward assignment and the like has been
+  * removed.
+  *
+  * Most notably, assignments of the form Vj0 <- ... + [a,b] have been
+  * replaced with Vj0 <- ... + [c,c] == c
+  */
+trait Octagon[N <: IField[N]] extends PartiallyOrdered[Octagon[N]] {
+  // Abstract tests (Mine' 2006 fig. 20 p. 42)
+  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N]
+  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N]
+  def test_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : Octagon[N]
+  def test_vj0_plus_vi0_le_c(vj0 : Var, vi0 : Var, c : N) : Octagon[N]
+  def test_minus_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : Octagon[N]
+
+  // Abstract assignment (Mine' 2006 fig. 15 p. 35)
+  def forget(f : Var) : Octagon[N]
+  ///
+  def assign_vj0_gets_c(j0 : Var, c : N) : Octagon[N]
+  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : Octagon[N]
+  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : Octagon[N]
+  def assign_vj0_gets_minus_vj0(j0 : Var) : Octagon[N]
+  def assign_vj0_gets_minus_vi0(j0: Var, i0 : Var) : Octagon[N] =
+    this.assign_vj0_gets_vi0(j0, i0).assign_vj0_gets_minus_vj0(j0)//
+  def assign_vj0_gets_minus_vj0_plus_c (j0 : Var, c : N) : Octagon[N] =
+    this.assign_vj0_gets_minus_vj0(j0).assign_vj0_gets_vj0_plus_c(j0, c) //
+  def assign_vj0_gets_minus_vi0_plus_c (j0 : Var, i0 : Var, c : N) : Octagon[N] =
+    this.assign_vj0_gets_minus_vi0(j0, i0).assign_vj0_gets_vj0_plus_c(j0, c) //
+
+  // This one is a little extra wrt the cases on the paper, it's
+  // needed for assign_vj0_gets_minus_vi0 Just implement it as a call
+  // to vj0_gets_vi0_plus_c with c = zero, when you have a zero for
+  // your N
+  protected def assign_vj0_gets_vi0(j0 : Var, i0 : Var) : Octagon[N]
+
+  //////
+  def isEmpty : Boolean
+  def isBottom : Boolean
+  def union(that : Octagon[N]) : Octagon[N]
+  def intersection(that : Octagon[N]) : Octagon[N]
+  def isTop : Boolean
+  def dimension : OctagonDim
+  //////
+  def widening(that : Octagon[N]) : Octagon[N]
+  def narrowing(that : Octagon[N]) : Octagon[N]
+
+  //////
+
+  /**
+    * Note: being a PatriallyOrdered means that you can compare
+    * octagons with <=.
+    *
+    * == calls .equals, which unless defined in each implementation
+    * amounts by default to reference comparison; you may want to use
+    * <= & >= instead.
+    */
+  def tryCompareTo[B >: Octagon[N]](other: B)(implicit arg0: (B) => PartiallyOrdered[B]): Option[Int]
+
+  def get_ineq_vi_minus_vj_leq_c(i : SignedVarIdx, j : SignedVarIdx) : Option[N]
+
+}
+
+case class BottomOctagon[N <: IField[N]] (override val dimension : OctagonDim) extends Octagon[N] {
+  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] = this
+  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] = this
+  def test_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : Octagon[N] = this
+  def test_vj0_plus_vi0_le_c(vj0 : Var, vi0 : Var, c : N) : Octagon[N] = this
+  def test_minus_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : Octagon[N] = this
+
+
+  def get_ineq_vi_minus_vj_leq_c(i : SignedVarIdx, j : SignedVarIdx) : Option[N] = None
+
+  //////
+  def forget(f : Var) : Octagon[N] = this
+  def assign_vj0_gets_c(j0 : Var, c : N):  Octagon[N] = this
+  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : Octagon[N] = this
+  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : Octagon[N] = this
+  def assign_vk_gets_e(k : Int) : Octagon[N] = this
+  def assign_vj0_gets_minus_vj0(j0 : Var) : Octagon[N] = this
+  def assign_vj0_gets_vi0 (j0 : Var, i0 : Var) : Octagon[N] = this
+  //////
+  def isEmpty : Boolean = true
+  def isBottom : Boolean = true
+  def isTop : Boolean = false
+  def union(that : Octagon[N]) = that
+  def intersection(that : Octagon[N]) = this
+  def widening(that : Octagon[N]) : Octagon[N] = that
+  def narrowing(that : Octagon[N]) : Octagon[N] = ???
+  //////
+  def tryCompareTo[B >: Octagon[N]](other: B)(implicit arg0: (B) => PartiallyOrdered[B]): Option[Int] =
+    other match {
+      case that : Octagon[N] =>
+        if (that.isBottom) Some(0)
+        else Some(-1)
+      case _ => None
+    }
+}
+
+//////////////////////
+// UTILS
+//////////////////////
+
+trait SignedVarIdx {
+  def i : Int
+  def bar : SignedVarIdx
+  def coeff : Int
+  def toVar : Var
+}
+
+/*
+ *  Each variable Vi ∈ V has both a positive form V_2i−1, and a
+ *  negative form V2i in V. Mine' 2006 p. 8.
+ */
+object SignedVarIdx {
+  def apply(i : Int) : SignedVarIdx = if (i % 2 == 0)
+    VMinusIdx(i)
+  else
+    VPlusIdx(i)
+}
+
+case class Var(i : Int) {
+  require(i != 0)
+  def negForm : VMinusIdx = VMinusIdx(2 * i)
+  def posForm : VPlusIdx = VPlusIdx(2 * i - 1)
+}
+
+case class VPlusIdx(i : Int) extends SignedVarIdx {
+  require (i != 0)
+  require(i % 2 == 1)
+  require (i != 0)
+  def bar = VMinusIdx(i + 1)
+  def coeff : Int = +1
+  def toVar = Var((i + 1) / 2)
+}
+
+case class VMinusIdx(i : Int) extends SignedVarIdx {
+  require (i != 0)
+  require(i % 2 == 0)
+  def bar = VPlusIdx(i - 1)
+  def coeff : Int = -1
+  def toVar = Var(i / 2)
+}
+
+case class OctagonDim(private val n : Int) {
+  require(n != 0)
+  def octagonDimToInt : Int = n
+  def allVars : Seq[Var] = (1 to n).map(Var(_))
+}

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/Octagon.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/Octagon.scala
@@ -21,7 +21,6 @@ import it.unich.jandom.utils.dbm._
 import it.unich.jandom.utils.numberext.IField
 import math.PartiallyOrdered
 
-
 /**
   * The definition of an object exposing a subset of the transfer
   * functions and attributes detailed in Mine' 2006, "The Octagon
@@ -34,95 +33,46 @@ import math.PartiallyOrdered
   * Most notably, assignments of the form Vj0 <- ... + [a,b] have been
   * replaced with Vj0 <- ... + [c,c] == c
   */
-trait Octagon[N <: IField[N]] extends PartiallyOrdered[Octagon[N]] {
+trait Octagon[N <: IField[N], O <: Octagon[N, O]]
+    extends PartiallyOrdered[O] {
+
   // Abstract tests (Mine' 2006 fig. 20 p. 42)
-  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N]
-  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N]
-  def test_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : Octagon[N]
-  def test_vj0_plus_vi0_le_c(vj0 : Var, vi0 : Var, c : N) : Octagon[N]
-  def test_minus_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : Octagon[N]
+  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : O
+  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : O
+  def test_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : O
+  def test_vj0_plus_vi0_le_c(vj0 : Var, vi0 : Var, c : N) : O
+  def test_minus_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : O
 
   // Abstract assignment (Mine' 2006 fig. 15 p. 35)
-  def forget(f : Var) : Octagon[N]
-  ///
-  def assign_vj0_gets_c(j0 : Var, c : N) : Octagon[N]
-  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : Octagon[N]
-  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : Octagon[N]
-  def assign_vj0_gets_minus_vj0(j0 : Var) : Octagon[N]
-  def assign_vj0_gets_minus_vi0(j0: Var, i0 : Var) : Octagon[N] =
+  def forget(f : Var) : O
+  def assign_vj0_gets_c(j0 : Var, c : N) : O
+  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : O
+  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : O
+  def assign_vj0_gets_minus_vj0(j0 : Var) : O
+  def assign_vj0_gets_minus_vi0(j0: Var, i0 : Var) : O =
     this.assign_vj0_gets_vi0(j0, i0).assign_vj0_gets_minus_vj0(j0)//
-  def assign_vj0_gets_minus_vj0_plus_c (j0 : Var, c : N) : Octagon[N] =
+  def assign_vj0_gets_minus_vj0_plus_c (j0 : Var, c : N) : O =
     this.assign_vj0_gets_minus_vj0(j0).assign_vj0_gets_vj0_plus_c(j0, c) //
-  def assign_vj0_gets_minus_vi0_plus_c (j0 : Var, i0 : Var, c : N) : Octagon[N] =
+  def assign_vj0_gets_minus_vi0_plus_c (j0 : Var, i0 : Var, c : N) : O =
     this.assign_vj0_gets_minus_vi0(j0, i0).assign_vj0_gets_vj0_plus_c(j0, c) //
 
   // This one is a little extra wrt the cases on the paper, it's
   // needed for assign_vj0_gets_minus_vi0 Just implement it as a call
   // to vj0_gets_vi0_plus_c with c = zero, when you have a zero for
   // your N
-  protected def assign_vj0_gets_vi0(j0 : Var, i0 : Var) : Octagon[N]
+  protected def assign_vj0_gets_vi0(j0 : Var, i0 : Var) : O
 
-  //////
   def isEmpty : Boolean
   def isBottom : Boolean
-  def union(that : Octagon[N]) : Octagon[N]
-  def intersection(that : Octagon[N]) : Octagon[N]
+  def union(that : O) : O
+  def intersection(that : O) : O
   def isTop : Boolean
   def dimension : OctagonDim
-  //////
-  def widening(that : Octagon[N]) : Octagon[N]
-  def narrowing(that : Octagon[N]) : Octagon[N]
-
-  //////
-
-  /**
-    * Note: being a PatriallyOrdered means that you can compare
-    * octagons with <=.
-    *
-    * == calls .equals, which unless defined in each implementation
-    * amounts by default to reference comparison; you may want to use
-    * <= & >= instead.
-    */
-  def tryCompareTo[B >: Octagon[N]](other: B)(implicit arg0: (B) => PartiallyOrdered[B]): Option[Int]
+  def widening(that : O) : O
+  def narrowing(that : O) : O
 
   def get_ineq_vi_minus_vj_leq_c(i : SignedVarIdx, j : SignedVarIdx) : Option[N]
 
-}
-
-case class BottomOctagon[N <: IField[N]] (override val dimension : OctagonDim) extends Octagon[N] {
-  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] = this
-  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] = this
-  def test_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : Octagon[N] = this
-  def test_vj0_plus_vi0_le_c(vj0 : Var, vi0 : Var, c : N) : Octagon[N] = this
-  def test_minus_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : Octagon[N] = this
-
-
-  def get_ineq_vi_minus_vj_leq_c(i : SignedVarIdx, j : SignedVarIdx) : Option[N] = None
-
-  //////
-  def forget(f : Var) : Octagon[N] = this
-  def assign_vj0_gets_c(j0 : Var, c : N):  Octagon[N] = this
-  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : Octagon[N] = this
-  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : Octagon[N] = this
-  def assign_vk_gets_e(k : Int) : Octagon[N] = this
-  def assign_vj0_gets_minus_vj0(j0 : Var) : Octagon[N] = this
-  def assign_vj0_gets_vi0 (j0 : Var, i0 : Var) : Octagon[N] = this
-  //////
-  def isEmpty : Boolean = true
-  def isBottom : Boolean = true
-  def isTop : Boolean = false
-  def union(that : Octagon[N]) = that
-  def intersection(that : Octagon[N]) = this
-  def widening(that : Octagon[N]) : Octagon[N] = that
-  def narrowing(that : Octagon[N]) : Octagon[N] = ???
-  //////
-  def tryCompareTo[B >: Octagon[N]](other: B)(implicit arg0: (B) => PartiallyOrdered[B]): Option[Int] =
-    other match {
-      case that : Octagon[N] =>
-        if (that.isBottom) Some(0)
-        else Some(-1)
-      case _ => None
-    }
 }
 
 //////////////////////
@@ -141,10 +91,8 @@ trait SignedVarIdx {
  *  negative form V2i in V. Mine' 2006 p. 8.
  */
 object SignedVarIdx {
-  def apply(i : Int) : SignedVarIdx = if (i % 2 == 0)
-    VMinusIdx(i)
-  else
-    VPlusIdx(i)
+  def apply(i : Int) : SignedVarIdx =
+    if (i % 2 == 0) VMinusIdx(i) else VPlusIdx(i)
 }
 
 case class Var(i : Int) {
@@ -179,4 +127,34 @@ case class OctagonDim(private val n : Int) {
 
 object OctagonDim {
   def apply(d : DBMDim) : OctagonDim = OctagonDim(d.dbmDimToInt / 2)
+}
+
+trait BottomOctagon[N <: IField[N], O <: Octagon[N, O]] {
+
+  def dimension: OctagonDim
+  def bottom : O
+
+  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : O = bottom
+  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : O = bottom
+  def test_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : O = bottom
+  def test_vj0_plus_vi0_le_c(vj0 : Var, vi0 : Var, c : N) : O = bottom
+  def test_minus_vj0_minus_vi0_plus_c_le_0(vj0 : Var, vi0 : Var, c : N) : O = bottom
+
+  def get_ineq_vi_minus_vj_leq_c(i : SignedVarIdx, j : SignedVarIdx) : Option[N] = None
+
+  def forget(f : Var) : O = bottom
+  def assign_vj0_gets_c(j0 : Var, c : N):  O = bottom
+  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : O = bottom
+  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : O = bottom
+  def assign_vk_gets_e(k : Int) : O = bottom
+  def assign_vj0_gets_minus_vj0(j0 : Var) : O = bottom
+  def assign_vj0_gets_vi0 (j0 : Var, i0 : Var) : O = bottom
+  //////
+  def isEmpty : Boolean = true
+  def isBottom : Boolean = true
+  def isTop : Boolean = false
+  def union(that : O) = that
+  def intersection(that : O) = bottom
+  def widening(that : O) : O = that
+  def narrowing(that : O) : O = ???
 }

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
@@ -176,7 +176,37 @@ case class OctagonProperty
 
   def linearDisequality(lf: LinearForm): Property = ???
 
-  def toBox : BoxRationalDomain#Property = ???
+  def toBox : BoxRationalDomain#Property = {
+    if (this.isEmpty) {
+      val suparr = Array.fill[RationalExt](dimension)(RationalExt.NegativeInfinity)
+      val infarr = Array.fill[RationalExt](dimension)(RationalExt.PositiveInfinity)
+      boxDomain.makeBox(infarr, suparr, true)
+    } else {
+      val cons = constraints.filter(_.homcoeffs.filter(_ != 0).size == 1)
+      val supcons = cons.filter(_.homcoeffs.filter(_ == 1).size == 1)
+      val infcons = cons.filter(_.homcoeffs.filter(_ == -1).size == 1)
+      val suparr = supcons.foldRight(Array.fill[RationalExt](dimension)(RationalExt.PositiveInfinity))(
+        (i : LinearForm, z : Array[RationalExt]) => {
+          val index = i.homcoeffs.indexOf(Rational(1))
+          assert(index != -1)
+          assert(index >= 0)
+          assert(index < dimension)
+          z.updated(index, RationalExt(-i.known))
+        }
+      )
+      val infarr = infcons.foldRight(Array.fill[RationalExt](dimension)(RationalExt.NegativeInfinity))(
+        (i : LinearForm, z : Array[RationalExt]) => {
+          val index = i.homcoeffs.indexOf(Rational(-1))
+          assert(index != -1)
+          assert(index >= 0)
+          assert(index < dimension)
+          z.updated(index, RationalExt(i.known))
+        })
+      boxDomain.makeBox(infarr, suparr, false)
+      // Cause: java.lang.IllegalArgumentException: requirement failed: The parameters low: -Infinity,0,-Infinity, high: Infinity,-1,Infinity and isEmpty: false are not normalized
+
+    }
+  }
 
   def minimize(lf: LinearForm) = ???
 

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
@@ -82,8 +82,7 @@ class OctagonPropertyModule[O <: Octagon[RationalExt, O], D <: OctagonDomainTrai
       * the Box domain
       */
     def linearAssignment(j0 : Int, l: LinearForm): Property = {
-      // TODO: Would it be a good idea to specially handle the cases with c = 0?
-      val lf = l.padded(dimension + 1) // TODO: splain
+      val lf = l.padded(dimension + 1)
       assert(lf.homcoeffs.size > j0, ""+lf + lf.homcoeffs + j0 + dimension)
       val zipped = lf.homcoeffs.zipWithIndex
       if (zipped.filter(_._1 != 0).size == 0)
@@ -98,7 +97,6 @@ class OctagonPropertyModule[O <: Octagon[RationalExt, O], D <: OctagonDomainTrai
             o.assign_vj0_gets_vj0_plus_c(Var(j0 + 1), lf.known)
         } else if (lf.homcoeffs(j0) == -1) {
           // Case 4. {{ Vj0 <- - Vj0 + c }}
-          // TODO OR NoT?
           if (lf.known == 0)
             o.assign_vj0_gets_minus_vj0(Var(j0 + 1)) // TODO: totally useless?
           else
@@ -218,7 +216,6 @@ class OctagonPropertyModule[O <: Octagon[RationalExt, O], D <: OctagonDomainTrai
             z.updated(index, RationalExt(i.known))
           })
         boxDomain.makeBox(infarr, suparr, false)
-        // Cause: java.lang.IllegalArgumentException: requirement failed: The parameters low: -Infinity,0,-Infinity, high: Infinity,-1,Infinity and isEmpty: false are not normalized
       }
     }
 

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
@@ -1,0 +1,116 @@
+/**
+  * Copyright 2018 Filippo Sestini, Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty ofa
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.domains.numerical.octagon
+import  it.unich.jandom.domains.numerical.OctagonDomain
+import  it.unich.jandom.domains.numerical.BoxRationalDomain
+import it.unich.jandom.domains.numerical.LinearForm
+import it.unich.jandom.domains.numerical.NumericalProperty
+import it.unich.jandom.utils.numberext.RationalExt
+import spire.math.Rational
+import it.unich.jandom.utils.numberext.StaticIField
+import scala.language.implicitConversions
+import math.PartiallyOrdered
+
+/**
+  * This class adapts a NumericalProperty interface to the Octagon
+  * interface, which exposes transfer functions and attributes found
+  * in Mine 2006 Fig. 15, Fig. 20, etc; moreover, it uses the Boxes
+  * domain as a fallback overapproximation.
+  *
+  * There is no actual octagon-related logic besides dispatching, nor
+  * any additional state mantained herein.
+  */
+case class OctagonProperty
+  (o : Octagon[RationalExt])
+  (implicit ifield : StaticIField[RationalExt], octDomain : OctagonDomain, boxDomain : BoxRationalDomain)
+    extends NumericalProperty[OctagonProperty] {
+
+  implicit def octagonToProperty (o : Octagon[RationalExt]) : OctagonProperty = OctagonProperty(o)
+
+  type Domain = OctagonDomain
+  type Property = OctagonProperty
+
+  def domain = octDomain
+
+
+  def dimension = o.dimension.octagonDimToInt
+
+  def widening(that : Property) = o.widening(that.o)
+
+  def narrowing(that : Property) = o.narrowing(that.o)
+
+  override def union(that: Property): Property = o.union(that.o)
+
+  override def intersection(that: Property): Property = o.intersection(that.o)
+
+  def nonDeterministicAssignment(n: Int): Property = ???
+
+  def linearAssignment(j0 : Int, l: LinearForm): Property = ???
+
+  def linearInequality(lf: LinearForm): Property = ???
+
+  def linearDisequality(lf: LinearForm): Property = ???
+
+  def toBox : BoxRationalDomain#Property = ???
+
+  def minimize(lf: LinearForm) = ???
+
+  def maximize(lf: LinearForm) = ???
+
+  def frequency(lf: LinearForm) = ???
+
+  def constraints : Seq[LinearForm] = ???
+
+  def isPolyhedral = true
+
+  def addVariable = ??? // TODO
+
+  def delVariable(n: Int) = ??? // TODO
+
+  def mapVariables(rho: Seq[Int]) = ??? // TODO
+
+  def isEmpty = isBottom
+
+  def isTop = o.isTop
+
+  def isBottom = o.isBottom
+
+  def bottom = domain.bottom(this.dimension)
+
+  def top = domain.top(this.dimension)
+
+  override def hashCode = 123456 + o.hashCode
+
+  def tryCompareTo[B >: OctagonProperty](other: B)(implicit arg0: (B) => PartiallyOrdered[B]): Option[Int] =
+    other match {
+      case OctagonProperty(othero) =>
+        (this.o.tryCompareTo(othero))
+      case _ => None
+    }
+
+  def mkString(vars: Seq[String]): String = {
+    if (isTop) {
+      "[ T ]"
+    } else if (isBottom) {
+      "[ _|_ ]"
+      } else {
+    "[ " + constraints + " ]"
+    }
+  }
+}

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
@@ -59,7 +59,10 @@ case class OctagonProperty
 
   override def intersection(that: Property): Property = o.intersection(that.o)
 
-  def nonDeterministicAssignment(n: Int): Property = ???
+  /**
+    * Approximated with forget
+    */
+  def nonDeterministicAssignment(n: Int): Property = o.forget(Var(n + 1))
 
   def linearAssignment(j0 : Int, l: LinearForm): Property = ???
 

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
@@ -174,7 +174,12 @@ case class OctagonProperty
     }
   }
 
-  def linearDisequality(lf: LinearForm): Property = ???
+  def linearDisequality(lf: LinearForm): Property = {
+    this
+    // TODO: Not doing anything in reponse to a {{ Vj0 != Lf }} is
+    // sound, but is there a better and general enough way to deal
+    // with this?
+  }
 
   def toBox : BoxRationalDomain#Property = {
     if (this.isEmpty) {

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/OctagonProperty.scala
@@ -113,7 +113,8 @@ case class OctagonProperty
     } else if (isBottom) {
       "[ _|_ ]"
       } else {
-    "[ " + constraints + " ]"
+    "[ " +// constraints
+      it.unich.jandom.domains.numerical.Inequalities.constraintsToInequalities(constraints).map(_.mkString(vars)).mkString("; ") + " ]"
     }
   }
 }

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
@@ -24,10 +24,7 @@ import it.unich.jandom.utils.numberext.StaticIField
 
 import scala.language.implicitConversions
 
-//////////////////////////////////////////////////////////////////
 // Some sugar to make the following stuff read more like Mine 2006
-//////////////////////////////////////////////////////////////////
-
 object OctSugar {
   implicit def OctagonDimToDBMDim(d: OctagonDim) : DBMDim = d.toDBMDim
   implicit def DBMtoOctagonDim(d : DBMDim) : OctagonDim = {
@@ -41,11 +38,6 @@ object OctSugar {
   implicit def octftodbmf[N] (f : OctIdx => N) : DBMIdx => N = (idx : DBMIdx) => f(OctIdx(idx))
   implicit def octidxtodbmidx (idx : OctIdx) : DBMIdx = idx.idx
 }
-
-//////////////////////////////
-// End sugar
-//////////////////////////////
-
 
 /**
   * An abstract implementation of an octagonal representation that
@@ -66,7 +58,23 @@ object OctSugar {
   *    always yield a closed DBM)
   */
 
-trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
+sealed trait OptimizedOctagon[N <: IField[N]] extends Octagon[N, OptimizedOctagon[N]]
+
+case class BottomOptOcta[N <: IField[N]] (dimension : OctagonDim)
+    extends OptimizedOctagon[N] with BottomOctagon[N, OptimizedOctagon[N]] {
+
+  def bottom = this
+  def tryCompareTo[B >: OptimizedOctagon[N]](other: B)
+    (implicit arg0: (B) => PartiallyOrdered[B]): Option[Int] =
+    other match {
+      case that : OptimizedOctagon[N] => if (that.isBottom) Some(0) else Some(-1)
+      case _ => None
+    }
+
+}
+
+trait NonBottomOptOcta[N <: IField[N]] extends OptimizedOctagon[N] {
+
   import OctSugar.octftodbmf
   import OctSugar.octidxtodbmidx
   import OctSugar.OctIdx
@@ -85,15 +93,15 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
   protected[octagon] def closedDbm : Option[ClosedDBM[N]]
   protected[octagon] def anyDbm : DBM[N]
 
-  protected[octagon] def onClosedDBM (f : ClosedDBM[N] => Octagon[N]) : Octagon[N]
-  protected[octagon] def onAnyDBM (f : DBM[N] => Octagon[N]) : Octagon[N]
-  protected[octagon] def onEither (ifNonClosed : DBM[N] => Octagon[N], ifClosed : ClosedDBM[N] => Octagon[N]) : Octagon[N]
+  protected[octagon] def onClosedDBM (f : ClosedDBM[N] => OptimizedOctagon[N]) : OptimizedOctagon[N]
+  protected[octagon] def onAnyDBM (f : DBM[N] => OptimizedOctagon[N]) : OptimizedOctagon[N]
+  protected[octagon] def onEither (ifNonClosed : DBM[N] => OptimizedOctagon[N], ifClosed : ClosedDBM[N] => OptimizedOctagon[N]) : OptimizedOctagon[N]
 
-  protected[octagon] def closeIncrementally (j0 : Var)(f : ClosedDBM[N] => DBMIdx => N) : ClosedDBM[N] => Octagon[N]
-  protected[octagon] def yieldClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => Octagon[N]
-  protected[octagon] def yieldClosed (dbm : DBM[N]) : Octagon[N]
-  protected[octagon] def yieldNonClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => Octagon[N]
-  protected[octagon] def yieldNonClosed (dbm : DBM[N]) : Octagon[N]
+  protected[octagon] def closeIncrementally (j0 : Var)(f : ClosedDBM[N] => DBMIdx => N) : ClosedDBM[N] => OptimizedOctagon[N]
+  protected[octagon] def yieldClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => OptimizedOctagon[N]
+  protected[octagon] def yieldClosed (dbm : DBM[N]) : OptimizedOctagon[N]
+  protected[octagon] def yieldNonClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => OptimizedOctagon[N]
+  protected[octagon] def yieldNonClosed (dbm : DBM[N]) : OptimizedOctagon[N]
 
   protected[octagon] def preserveClosure (f : DBM[N] => DBMIdx => N) =
     onEither(
@@ -101,40 +109,9 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
       ifNonClosed = yieldNonClosed(f))
 
 
-  /////////////////////////////////////////////////////////////////////
-
-
-  ////////////////////////////////////
-  // Begin octagon transfer functions
-  ////////////////////////////////////
-
-
-  // If the argument is closed the result is guaranteed to ble closed already (Mine' 2006 Fig. 26 p. 54)
-  def forget(f : Var) = preserveClosure(
-    forget_f(_)(f)
-  )
-
-  def forget_f(m : DBM[N]) (f : Var) (idx : OctIdx) =
-      if (
-        idx.i != f.posForm &
-          idx.i != f.negForm &
-          idx.j != f.posForm &
-          idx.j != f.negForm)
-        m(idx) : N
-      else if (idx.i == idx.j & idx.j == f.posForm | idx.i == idx.j & idx.j == f.negForm)
-        ifield.zero : N
-      else
-        ifield.PositiveInfinity : N
-
-
-  //////////////////
-  // Abstract tests
-  //////////////////
-
-  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] = {
+  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : OptimizedOctagon[N] = {
     // Case 1. Mine' 2006 fig. 20 p. 42
     // {{ Vj0 + c <= 0 ? }}
-
     def f (m : DBM[N]) (idx : OctIdx) =
       if (idx.i == j0.negForm & idx.j == j0.posForm)
         m(idx).min(-c._x_2)
@@ -155,7 +132,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
     // (Mine' 2006 p. 42)
   }
 
-  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] = {
+  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : OptimizedOctagon[N] = {
     // Case 2. Mine' 2006 fig. 20 p. 42
     // {{ -Vj0 + c <= 0 ? }}
 
@@ -170,7 +147,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
       ifClosed = closeIncrementally(j0)(f(_)))
   }
 
-  def test_vj0_minus_vi0_plus_c_le_0(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+  def test_vj0_minus_vi0_plus_c_le_0(j0 : Var, i0 : Var, c : N) : OptimizedOctagon[N] = {
     // Case 3. Mine' 2006 fig. 20 p. 42
     // {{ -Vj0 + Vi0- + c <= 0 ? }}
 
@@ -188,8 +165,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
       ifClosed = closeIncrementally(j0)(f(_)))
   }
 
-
-  def test_vj0_plus_vi0_le_c(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+  def test_vj0_plus_vi0_le_c(j0 : Var, i0 : Var, c : N) : OptimizedOctagon[N] = {
     // Case 4. Mine' 2006 fig. 20 p. 42
     // {{ Vj0 + Vi0- + c <= 0 ? }}
     require(j0 != i0) // see fig. 20
@@ -206,8 +182,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
       ifClosed = closeIncrementally(j0)(f(_)))
   }
 
-
-  def test_minus_vj0_minus_vi0_plus_c_le_0(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+  def test_minus_vj0_minus_vi0_plus_c_le_0(j0 : Var, i0 : Var, c : N) : OptimizedOctagon[N] = {
     // Case 5. Mine' 2006 fig. 20 p. 42
     // {{ -Vj0 + Vi0- + c <= 0 ? }}
     require(j0 != i0)
@@ -224,11 +199,23 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
       ifClosed = closeIncrementally(j0)(f(_)))
   }
 
-  ///////////////////////
-  // Abstract assignment
-  ///////////////////////
+  // If the argument is closed the result is guaranteed to ble closed already
+  // (Mine' 2006 Fig. 26 p. 54)
+  def forget(f : Var) = preserveClosure(forget_f(_)(f))
 
-  def assign_vj0_gets_c(j0 : Var, c : N) : Octagon[N] =
+  def forget_f(m : DBM[N]) (f : Var) (idx : OctIdx) =
+      if (
+        idx.i != f.posForm &
+          idx.i != f.negForm &
+          idx.j != f.posForm &
+          idx.j != f.negForm)
+        m(idx) : N
+      else if (idx.i == idx.j & idx.j == f.posForm | idx.i == idx.j & idx.j == f.negForm)
+        ifield.zero : N
+      else
+        ifield.PositiveInfinity : N
+
+  def assign_vj0_gets_c(j0 : Var, c : N) : OptimizedOctagon[N] =
     // Case 1. Mine' 2006 fig. 15 p. 35
     // {{ Vj0 <- c }}
     onClosedDBM(
@@ -245,7 +232,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
           else
             forget_f(m)(j0)(idx)))
 
-  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : Octagon[N] =
+  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : OptimizedOctagon[N] =
     // Case 2. Mine' 2006 fig. 15 p. 35
     // {{ Vj0 <- Vj0 + c }}
     preserveClosure(
@@ -267,9 +254,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
         else
           m(idx))
 
-
-
-  def assign_vj0_gets_minus_vj0(j0 : Var) : Octagon[N] =
+  def assign_vj0_gets_minus_vj0(j0 : Var) : OptimizedOctagon[N] =
     // Case 4. Mine' 2006 fig. 15 p. 35
     // {{ Vj0 <- -Vj0 }}
     preserveClosure(
@@ -294,7 +279,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
             !(Seq(j0.posForm, j0.negForm) contains idx.j))
           m(idx)})
 
-  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : OptimizedOctagon[N] = {
     // Case 3. Mine' 2006 fig. 15 p. 35
     // {[ Vj0 <- Vi0 + c }}
     require (j0 != i0)
@@ -316,15 +301,14 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
         else
           forget_f(m)(j0)(idx)))}
 
-  /////////////////////////////////////
-
   /**
     *  The indices *look* swapped here but are not.  Cfr Mine 2006
     *  p.7, "the element at line i, column j, where 1 ≤ i ≤ n, 1 ≤ j ≤
     *  n, denoted by mij equals c ∈ I if there is a constraint of the
     *  form Vj − Vi ≤ c ..."
     */
-  def get_ineq_vi_minus_vj_leq_c(j : SignedVarIdx, i : SignedVarIdx) : Option[N] = closedDbm.map(_(DBMIdx(i.i, j.i)))
+  def get_ineq_vi_minus_vj_leq_c(j : SignedVarIdx, i : SignedVarIdx) : Option[N] =
+    closedDbm.map(_(DBMIdx(i.i, j.i)))
 
   def isEmpty = isBottom
 
@@ -334,117 +318,93 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
   }
 
   def isTop = anyDbm.isTop
-
   def dimension : OctagonDim
 
-  def union(that : Octagon[N]) : Octagon[N] = {
+  def union(that : OptimizedOctagon[N]) : OptimizedOctagon[N] = {
     that match {
-      case bot : BottomOctagon[N] => { assert (bot.dimension == this.dimension); this }
-      case o : OptimizedOctagon[N] => { assert (o.dimension == this.dimension);
+      case bot : BottomOptOcta[N] => { assert (bot.dimension == this.dimension); this }
+      case o : NonBottomOptOcta[N] => { assert (o.dimension == this.dimension);
         o.closedDbm match {
           case Some(them) =>
             this.closedDbm match {
               case Some(us) => yieldClosed(us union them)
               // Result of union of two closed DBMs is closed (Mine' 2006 Fig. 27 p. 54)
-              case None => BottomOctagon[N](this.dimension)
+              case None => BottomOptOcta[N](this.dimension)
             }
-          case _ => BottomOctagon[N](this.dimension)
+          case _ => BottomOptOcta[N](this.dimension)
         }
       }
-      case _ => ??? // Not implemented
     }
   }
 
-  def intersection(that : Octagon[N]) : Octagon[N] = {
+  def intersection(that : OptimizedOctagon[N]) : OptimizedOctagon[N] = {
     that match {
-      case bot : BottomOctagon[N] => { assert (bot.dimension == this.dimension); that }
-      case o : OptimizedOctagon[N] => { assert (o.dimension == this.dimension);
+      case bot : BottomOptOcta[N] => { assert (bot.dimension == this.dimension); that }
+      case o : NonBottomOptOcta[N] => { assert (o.dimension == this.dimension);
         yieldNonClosed(o.anyDbm.intersection(this.anyDbm))
         // Closure is not guaranteed even if operands are closed,
       }
-      case _ => ??? // Not implemented
     }
   }
 
-  def widening(that : Octagon[N]) : Octagon[N] =
-    if (that.isBottom)
-      this
-    else
-      that match {
-        case bot : BottomOctagon[N] => this
-        case o   : OptimizedOctagon[N] =>
-          this.closedDbm.flatMap(us =>
-            o.closedDbm.map(
-              them =>
-              us.combine((us, them) =>
-                if (us >= them) us
-                else ifield.PositiveInfinity)(them))) match {
-            case None => BottomOctagon(dimension)
-            case Some(dbm) => yieldNonClosed(dbm)
-          }
-      }
+  def widening(that : OptimizedOctagon[N]) : OptimizedOctagon[N] =
+    that match {
+      case bot : BottomOptOcta[N] => this
+      case o   : NonBottomOptOcta[N] =>
+        this.closedDbm.flatMap(us =>
+          o.closedDbm.map(
+            them =>
+            us.combine((us, them) =>
+              if (us >= them) us
+              else ifield.PositiveInfinity)(them))) match {
+          case None => BottomOptOcta(dimension)
+          case Some(dbm) => yieldNonClosed(dbm)
+        }
+    }
 
-  def narrowing(that : Octagon[N]) : Octagon[N] =
-    if (that.isBottom)
-      that
-    else
-      that match {
-        case bot : BottomOctagon[N] => that
-        case o   : OptimizedOctagon[N] =>
-          this.closedDbm.flatMap(us =>
-            o.closedDbm.map(
-              them =>
-              us.combine((us, them) =>
-                if (us == ifield.PositiveInfinity) them
-                else us)(them))) match {
-            case None => BottomOctagon(dimension)
-            case Some(dbm) => yieldNonClosed(dbm)
-          }
-     }
+  def narrowing(that : OptimizedOctagon[N]) : OptimizedOctagon[N] =
+    that match {
+      case bot : BottomOptOcta[N] => that
+      case o   : NonBottomOptOcta[N] =>
+        this.closedDbm.flatMap(us =>
+          o.closedDbm.map(
+            them =>
+            us.combine((us, them) =>
+              if (us == ifield.PositiveInfinity) them
+              else us)(them))) match {
+          case None => BottomOptOcta(dimension)
+          case Some(dbm) => yieldNonClosed(dbm)
+        }
+    }
 
+  def tryCompareTo[B >: OptimizedOctagon[N]](other: B)
+    (implicit arg0: (B) => PartiallyOrdered[B]): Option[Int] = {
 
-
-
-  ////////////////////////////////////////
-
-  def tryCompareTo[B >: Octagon[N]](other: B)(implicit arg0: (B) => PartiallyOrdered[B]): Option[Int] = {
     this.closedDbm match {
       case Some(us) => other match {
-        case _ : BottomOctagon[N] => Some(1) // They're bottom, we're greater
-        case o : OptimizedOctagon[N] => o.closedDbm match {
+        case _ : BottomOptOcta[N] => Some(1) // They're bottom, we're greater
+        case o : NonBottomOptOcta[N] => o.closedDbm match {
           case Some(them) => us.tryCompareTo(them)
           case None => Some(1) // They're bottom, we're greater
         }
-        //// Additional case for comparing with SimpleOctagons
-        // case s : simple.SimpleOctagon[N] => us.tryCompareTo(s.m)
-        ////
         case _ => ??? // Not impl
       }
       case None => other match {
-        case _ : BottomOctagon[N] => Some(0) // They're bottom,
-                                             // we're also bottom
-        case o : OptimizedOctagon[N] => o.closedDbm match {
-          case Some(them) => Some(-1) // They're greater, we're
-                                      // bottom
+        case _ : BottomOptOcta[N] => Some(0) // They're bottom, we're also bottom
+        case o : NonBottomOptOcta[N] => o.closedDbm match {
           case None => Some(0)        // Both bottom
+          case Some(them) => Some(-1) // They're greater, we're bottom
         }
-        //// Additional case for comparing with SimpleOctagons
-        // case s : simple.SimpleOctagon[N] => Some(-1) // They're a
-                                                        // closed
-                                                        // non-bottom
-                                                     // DBM, we
-                                                     // are
-                                                     // bottom
         case _ => ??? // Not impl
       }
     }
   }
+
 }
 
 ///////////////////
 // Implementations
 ///////////////////
-
 
 /**
   * This avoids optimizations and, particularly, mantains the
@@ -462,40 +422,42 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
   */
 class PedanticOctagon[N <: IField[N]]
   (val dbm : ClosedDBM[N])
-  (implicit val ifield : StaticIField[N], cs : MineFloydWarshall[N], fac : DBMFactory[N]) extends OptimizedOctagon[N] {
+  (implicit val ifield : StaticIField[N], cs : MineFloydWarshall[N], fac : DBMFactory[N])
+    extends NonBottomOptOcta[N] {
 
-  protected def assign_vj0_gets_vi0(j0 : Var, i0 : Var) : Octagon[N] = assign_vj0_gets_vi0_plus_c(j0, i0, ifield.zero)
+  protected def assign_vj0_gets_vi0(j0 : Var, i0 : Var) : OptimizedOctagon[N] =
+    assign_vj0_gets_vi0_plus_c(j0, i0, ifield.zero)
 
   /////////////
 
   protected[octagon] def anyDbm : DBM[N] = dbm
   protected[octagon] def closedDbm : Option[ClosedDBM[N]] = Some(dbm)
 
-  protected def wrap(dbm : Option[ClosedDBM[N]]) : Octagon[N] = dbm match {
+  protected def wrap(dbm : Option[ClosedDBM[N]]) : OptimizedOctagon[N] = dbm match {
     case Some (closed) => new PedanticOctagon[N](closed)
-    case None => BottomOctagon(dimension)
+    case None => BottomOptOcta(dimension)
   }
 
-  protected[octagon] def onClosedDBM (f : ClosedDBM[N] => Octagon[N]) : Octagon[N] = f(dbm)
+  protected[octagon] def onClosedDBM (f : ClosedDBM[N] => OptimizedOctagon[N]) : OptimizedOctagon[N] = f(dbm)
 
-  protected[octagon] def onAnyDBM (f : DBM[N] => Octagon[N]) : Octagon[N] = f(dbm)
+  protected[octagon] def onAnyDBM (f : DBM[N] => OptimizedOctagon[N]) : OptimizedOctagon[N] = f(dbm)
 
-  protected[octagon] def onEither (ifNonClosed : DBM[N] => Octagon[N], ifClosed : ClosedDBM[N] => Octagon[N]) : Octagon[N] = ifClosed(dbm)
+  protected[octagon] def onEither (ifNonClosed : DBM[N] => OptimizedOctagon[N], ifClosed : ClosedDBM[N] => OptimizedOctagon[N]) : OptimizedOctagon[N] = ifClosed(dbm)
 
 
-  protected[octagon] def closeIncrementally (j0 : Var)(f : ClosedDBM[N] => DBMIdx => N) : ClosedDBM[N] => Octagon[N] = {
+  protected[octagon] def closeIncrementally (j0 : Var)(f : ClosedDBM[N] => DBMIdx => N) : ClosedDBM[N] => OptimizedOctagon[N] = {
     (closed : ClosedDBM[N]) => wrap(cs.strongClosure(fac.fromFun(dbm.dimension, f(closed))))
   }
-  protected[octagon] def yieldClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => Octagon[N] = {
+  protected[octagon] def yieldClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => OptimizedOctagon[N] = {
     (dbm : DBM[N]) => wrap(cs.strongClosure(fac.fromFun(dbm.dimension, f(dbm))))
   }
-  protected[octagon] def yieldClosed (dbm : DBM[N]) : Octagon[N] = {
+  protected[octagon] def yieldClosed (dbm : DBM[N]) : OptimizedOctagon[N] = {
     wrap(cs.strongClosure(dbm))
   }
-  protected[octagon] def yieldNonClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => Octagon[N] = {
+  protected[octagon] def yieldNonClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => OptimizedOctagon[N] = {
     (dbm : DBM[N]) => wrap(cs.stronglyClosed(dbm.dimension)(f(dbm)))
   }
-  protected[octagon] def yieldNonClosed (dbm : DBM[N]) : Octagon[N] = {
+  protected[octagon] def yieldNonClosed (dbm : DBM[N]) : OptimizedOctagon[N] = {
     wrap(cs.strongClosure(dbm))
   }
 
@@ -508,9 +470,10 @@ class PedanticOctagon[N <: IField[N]]
   */
 class DelayedOctagon[N <: IField[N]]
   (val dbm : Either[DBM[N], ClosedDBM[N]])
-  (implicit val ifield : StaticIField[N], cs : IncrementalMineFloydWarshall[N], fac : DBMFactory[N]) extends OptimizedOctagon[N] {
+  (implicit val ifield : StaticIField[N], cs : IncrementalMineFloydWarshall[N], fac : DBMFactory[N])
+    extends NonBottomOptOcta[N] {
 
-  protected def assign_vj0_gets_vi0(j0 : Var, i0 : Var) : Octagon[N] =
+  protected def assign_vj0_gets_vi0(j0 : Var, i0 : Var) : OptimizedOctagon[N] =
     assign_vj0_gets_vi0_plus_c(j0, i0, ifield.zero)
 
   protected[octagon] def anyDbm : DBM[N] = dbm match {
@@ -525,22 +488,22 @@ class DelayedOctagon[N <: IField[N]]
   }
 
 
-  protected def wrapAny(dbm : DBM[N]) : Octagon[N] = new DelayedOctagon[N](Left(dbm))
-  protected def wrapClosed(maybe : Option[ClosedDBM[N]]) : Octagon[N] = maybe match {
-    case None => BottomOctagon(dimension)
+  protected def wrapAny(dbm : DBM[N]) : OptimizedOctagon[N] = new DelayedOctagon[N](Left(dbm))
+  protected def wrapClosed(maybe : Option[ClosedDBM[N]]) : OptimizedOctagon[N] = maybe match {
+    case None => BottomOptOcta(dimension)
     case Some(closed) => new DelayedOctagon[N](Right(closed))
   }
 
-  protected[octagon] def onClosedDBM (f : ClosedDBM[N] => Octagon[N]) : Octagon[N] = closedDbm match {
+  protected[octagon] def onClosedDBM (f : ClosedDBM[N] => OptimizedOctagon[N]) : OptimizedOctagon[N] = closedDbm match {
     case Some(closed) => f(closed)
-    case None => BottomOctagon(dimension)
+    case None => BottomOptOcta(dimension)
   }
 
-  protected[octagon] def onAnyDBM (f : DBM[N] => Octagon[N]) : Octagon[N] = {
+  protected[octagon] def onAnyDBM (f : DBM[N] => OptimizedOctagon[N]) : OptimizedOctagon[N] = {
     f(anyDbm)
   }
 
-  protected[octagon] def onEither (ifNonClosed : DBM[N] => Octagon[N], ifClosed : ClosedDBM[N] => Octagon[N]) : Octagon[N] =
+  protected[octagon] def onEither (ifNonClosed : DBM[N] => OptimizedOctagon[N], ifClosed : ClosedDBM[N] => OptimizedOctagon[N]) : OptimizedOctagon[N] =
     dbm match {
       case Left(anyDbm) => ifNonClosed(anyDbm)
       case Right(closed) => ifClosed(closed)
@@ -548,27 +511,25 @@ class DelayedOctagon[N <: IField[N]]
 
   private def dbmDimension = anyDbm.dimension
 
-  protected[octagon] def closeIncrementally (j0 : Var)(f : ClosedDBM[N] => DBMIdx => N) : ClosedDBM[N] => Octagon[N] = {
+  protected[octagon] def closeIncrementally (j0 : Var)(f : ClosedDBM[N] => DBMIdx => N) : ClosedDBM[N] => OptimizedOctagon[N] = {
     (closed : ClosedDBM[N]) => wrapClosed(cs.incrementallyClosed(j0)(dbmDimension)(f(closed)))
   }
-  protected[octagon] def yieldClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => Octagon[N] = {
+  protected[octagon] def yieldClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => OptimizedOctagon[N] = {
     (dbm : DBM[N]) => wrapClosed(Some(cs.makeClosed(dbmDimension)(f(dbm))))
   }
-  protected[octagon] def yieldClosed (dbm : DBM[N]) : Octagon[N] = {
+  protected[octagon] def yieldClosed (dbm : DBM[N]) : OptimizedOctagon[N] = {
     wrapClosed(Some(cs.markAsClosed(dbm)))
   }
 
-  protected[octagon] def yieldNonClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => Octagon[N] = {
+  protected[octagon] def yieldNonClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => OptimizedOctagon[N] = {
     (dbm : DBM[N]) => wrapAny(fac.fromFun(dbmDimension, f(dbm)))
   }
-  protected[octagon] def yieldNonClosed (dbm : DBM[N]) : Octagon[N] = {
+  protected[octagon] def yieldNonClosed (dbm : DBM[N]) : OptimizedOctagon[N] = {
     wrapAny(dbm)
   }
 
   def dimension = OctagonDim(anyDbm.dimension)
 }
-
-
 
 /**
   * This one is like DelayedOctagon but is mutable and caches closure.
@@ -581,9 +542,9 @@ class CachingOctagon[N <: IField[N]]
 
   var cached_closed : Option[Option[ClosedDBM[N]]] = None
 
-  override protected def wrapAny(dbm : DBM[N]) : Octagon[N] = new CachingOctagon[N](Left(dbm))
-  override protected def wrapClosed(maybe : Option[ClosedDBM[N]]) : Octagon[N] = maybe match {
-    case None => BottomOctagon(dimension)
+  override protected def wrapAny(dbm : DBM[N]) : OptimizedOctagon[N] = new CachingOctagon[N](Left(dbm))
+  override protected def wrapClosed(maybe : Option[ClosedDBM[N]]) : OptimizedOctagon[N] = maybe match {
+    case None => BottomOptOcta(dimension)
     case Some(closed) => new CachingOctagon[N](Right(closed))
   }
 

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
@@ -380,7 +380,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
             o.closedDbm.map(
               them =>
               us.combine((us, them) =>
-                if (us > them) us
+                if (us >= them) us
                 else ifield.PositiveInfinity)(them))) match {
             case None => BottomOctagon(dimension)
             case Some(dbm) => yieldNonClosed(dbm) // TODO: Is this guaranteed closed already?

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
@@ -333,10 +333,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
     case None => true
   }
 
-  def isTop = closedDbm.map(_.isTop) match {
-    case Some(t) => t
-    case None => false
-  }
+  def isTop = anyDbm.isTop
 
   def dimension : OctagonDim
 

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
@@ -383,7 +383,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
                 if (us >= them) us
                 else ifield.PositiveInfinity)(them))) match {
             case None => BottomOctagon(dimension)
-            case Some(dbm) => yieldNonClosed(dbm) // TODO: Is this guaranteed closed already?
+            case Some(dbm) => yieldNonClosed(dbm)
           }
       }
 
@@ -401,7 +401,7 @@ trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
                 if (us == ifield.PositiveInfinity) them
                 else us)(them))) match {
             case None => BottomOctagon(dimension)
-            case Some(dbm) => yieldNonClosed(dbm) // TODO: Is this guaranteed closed already?
+            case Some(dbm) => yieldNonClosed(dbm)
           }
      }
 

--- a/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/octagon/optimized/OptimizedOctagon.scala
@@ -1,0 +1,445 @@
+/**
+  * Copyright 2018 Filippo Sestini, Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty ofa
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.domains.numerical.octagon.optimized
+import it.unich.jandom.domains.numerical.octagon._
+import it.unich.jandom.utils.dbm._
+import it.unich.jandom.utils.numberext.IField
+import it.unich.jandom.utils.numberext.StaticIField
+
+import scala.language.implicitConversions
+
+//////////////////////////////////////////////////////////////////
+// Some sugar to make the following stuff read more like Mine 2006
+//////////////////////////////////////////////////////////////////
+
+object OctSugar {
+  implicit def OctagonDimToDBMDim(d: OctagonDim) : DBMDim = d.toDBMDim
+  implicit def DBMtoOctagonDim(d : DBMDim) : OctagonDim = {
+    require(d.dbmDimToInt > 0 && (d.dbmDimToInt) % 2 == 0)
+    OctagonDim(d.dbmDimToInt / 2)
+  }
+  case class OctIdx(idx : DBMIdx) {
+    def i = SignedVarIdx(idx.i)
+    def j = SignedVarIdx(idx.j)
+  }
+  implicit def octftodbmf[N] (f : OctIdx => N) : DBMIdx => N = (idx : DBMIdx) => f(OctIdx(idx))
+  implicit def octidxtodbmidx (idx : OctIdx) : DBMIdx = idx.idx
+}
+
+//////////////////////////////
+// End sugar
+//////////////////////////////
+
+
+/**
+  * An abstract implementation of an octagonal representation that
+  * uses a DBM as its backend (basically, this _is_ a Mine'-style
+  * octagon, the artificial separation is for convenience of
+  * e.g. testing, stubbing).
+  *
+  * Leverages the Template Method pattern to inject different closure
+  * behaviours.
+  *
+  * It allows to optimize the implementation by:
+  *
+  * 1. Keeping a non-closed inner matrix and performing the closure on
+  *    request
+  *
+  * 2. Performing an incremental or noop closure when there is proof
+  *    of its sufficiency (i.e. those operations which are known to
+  *    always yield a closed DBM)
+  */
+
+trait OptimizedOctagon[N <: IField[N]] extends Octagon[N] {
+  import OctSugar.octftodbmf
+  import OctSugar.octidxtodbmidx
+  import OctSugar.OctIdx
+
+  protected def ifield : StaticIField[N]
+
+  //////////////////////////////////////////////////////////////
+  // Utilities relative to implementation and delaying behaviour
+  //////////////////////////////////////////////////////////////
+
+  /**
+    * A closed version of the underlying DBM for this Octagon.  If the
+    * implementation doesn't keep a closed DBM at all times, the
+    * implementation of this method is to perform the closure.
+    */
+  protected[octagon] def closedDbm : Option[ClosedDBM[N]]
+  protected[octagon] def anyDbm : DBM[N]
+
+  protected[octagon] def onClosedDBM (f : ClosedDBM[N] => Octagon[N]) : Octagon[N]
+  protected[octagon] def onAnyDBM (f : DBM[N] => Octagon[N]) : Octagon[N]
+  protected[octagon] def onEither (ifNonClosed : DBM[N] => Octagon[N], ifClosed : ClosedDBM[N] => Octagon[N]) : Octagon[N]
+
+  protected[octagon] def closeIncrementally (j0 : Var)(f : ClosedDBM[N] => DBMIdx => N) : ClosedDBM[N] => Octagon[N]
+  protected[octagon] def yieldClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => Octagon[N]
+  protected[octagon] def yieldClosed (dbm : DBM[N]) : Octagon[N]
+  protected[octagon] def yieldNonClosed (f : DBM[N] => DBMIdx => N) : DBM[N] => Octagon[N]
+  protected[octagon] def yieldNonClosed (dbm : DBM[N]) : Octagon[N]
+
+  protected[octagon] def preserveClosure (f : DBM[N] => DBMIdx => N) =
+    onEither(
+      ifClosed = yieldClosed(f),
+      ifNonClosed = yieldNonClosed(f))
+
+
+  /////////////////////////////////////////////////////////////////////
+
+
+  ////////////////////////////////////
+  // Begin octagon transfer functions
+  ////////////////////////////////////
+
+
+  // If the argument is closed the result is guaranteed to ble closed already (Mine' 2006 Fig. 26 p. 54)
+  def forget(f : Var) = preserveClosure(
+    forget_f(_)(f)
+  )
+
+  def forget_f(m : DBM[N]) (f : Var) (idx : OctIdx) =
+      if (
+        idx.i != f.posForm &
+          idx.i != f.negForm &
+          idx.j != f.posForm &
+          idx.j != f.negForm)
+        m(idx) : N
+      else if (idx.i == idx.j & idx.j == f.posForm | idx.i == idx.j & idx.j == f.negForm)
+        ifield.zero : N
+      else
+        ifield.PositiveInfinity : N
+
+
+  //////////////////
+  // Abstract tests
+  //////////////////
+
+  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] = {
+    // Case 1. Mine' 2006 fig. 20 p. 42
+    // {{ Vj0 + c <= 0 ? }}
+
+    def f (m : DBM[N]) (idx : OctIdx) =
+      if (idx.i == j0.negForm & idx.j == j0.posForm)
+        m(idx).min(-c._x_2)
+      else
+        m(idx)
+
+    onEither(
+      ifNonClosed = yieldNonClosed(f(_)),
+      ifClosed = closeIncrementally(j0)(f(_)))
+
+    // This test transfer function does not require a strongly closed
+    // argument (Mine' 2006 p. 42)
+
+    // If the argument is strongly closed, the result can be made
+    // strongly closed in quadratic time by applying the incremental
+    // strong closure The same applies to all exact octagonal tests.
+
+    // (Mine' 2006 p. 42)
+  }
+
+  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] = {
+    // Case 2. Mine' 2006 fig. 20 p. 42
+    // {{ -Vj0 + c <= 0 ? }}
+
+    def f (m : DBM[N])(idx : OctIdx) =
+      if (idx.i == j0.posForm & idx.j == j0.negForm)
+        m(idx).min(-c._x_2)
+      else
+        m(idx)
+
+    onEither( // See comment in test_vj0_plus_c_le_0
+      ifNonClosed = yieldNonClosed(f(_)),
+      ifClosed = closeIncrementally(j0)(f(_)))
+  }
+
+  def test_vj0_minus_vi0_plus_c_le_0(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+    // Case 3. Mine' 2006 fig. 20 p. 42
+    // {{ -Vj0 + Vi0- + c <= 0 ? }}
+
+    require(j0 != i0) // see fig. 20
+
+    def f (m :DBM[N]) (idx : OctIdx) =
+    if (idx.i == i0.posForm & idx.j == j0.posForm
+      | idx.i == j0.negForm & idx.j == i0.negForm)
+      m(idx).min(-c)
+    else
+      m(idx)
+
+    onEither( // See comment in test_vj0_plus_c_le_0
+      ifNonClosed = yieldNonClosed(f(_)),
+      ifClosed = closeIncrementally(j0)(f(_)))
+  }
+
+
+  def test_vj0_plus_vi0_le_c(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+    // Case 4. Mine' 2006 fig. 20 p. 42
+    // {{ Vj0 + Vi0- + c <= 0 ? }}
+    require(j0 != i0) // see fig. 20
+
+    def f (m : DBM[N]) (idx : OctIdx) =
+      if (idx.i == i0.negForm & idx.j == j0.posForm
+        | idx.i == j0.negForm & idx.j == i0.posForm)
+        m(idx).min(-c)
+      else
+        m(idx)
+
+    onEither( // See comment in test_vj0_plus_c_le_0
+      ifNonClosed = yieldNonClosed(f(_)),
+      ifClosed = closeIncrementally(j0)(f(_)))
+  }
+
+
+  def test_minus_vj0_minus_vi0_plus_c_le_0(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+    // Case 5. Mine' 2006 fig. 20 p. 42
+    // {{ -Vj0 + Vi0- + c <= 0 ? }}
+    require(j0 != i0)
+
+    def f(m : DBM[N]) (idx : OctIdx) =
+        if (idx.i == i0.posForm & idx.j == j0.negForm
+          | idx.i == j0.posForm & idx.j == i0.negForm)
+          m(idx).min(-c)
+        else
+          m(idx)
+
+    onEither( // See comment in test_vj0_plus_c_le_0
+      ifNonClosed = yieldNonClosed(f(_)),
+      ifClosed = closeIncrementally(j0)(f(_)))
+  }
+
+  ///////////////////////
+  // Abstract assignment
+  ///////////////////////
+
+  def assign_vj0_gets_c(j0 : Var, c : N) : Octagon[N] =
+    // Case 1. Mine' 2006 fig. 15 p. 35
+    // {{ Vj0 <- c }}
+    onClosedDBM(
+      closeIncrementally(j0)(
+      // Non-invertible assignments require a strongly closed argument
+      // [...]  due to the embedded forget operator, [...] the result
+      // can be strongly closed by performing incremental closure wrt
+      // the assigned variable (Mine' 2006 p.36)
+      (m : ClosedDBM[N]) => (idx : OctIdx) =>
+          if (idx.i == j0.posForm & idx.j == j0.negForm)
+            (-c._x_2)
+          else if (idx.i == j0.negForm & idx.j == j0.posForm)
+            (c._x_2)
+          else
+            forget_f(m)(j0)(idx)))
+
+  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : Octagon[N] =
+    // Case 2. Mine' 2006 fig. 15 p. 35
+    // {{ Vj0 <- Vj0 + c }}
+    preserveClosure(
+      // Invertible assignments do not require strongly closed
+      // matrix arguments but preserve the strong closure (Mine'
+      // 2006 p. 34)
+      (m : DBM[N]) => (idx : OctIdx) =>
+        if (idx.i == j0.posForm & idx.j != j0.posForm & idx.j != j0.negForm ||
+            idx.j == j0.negForm & idx.i != j0.posForm & idx.i != j0.negForm)
+          m(idx) - c // Jandom doesn't support interval assignment, so [a,b] = [c,c]
+        else if
+          (idx.i != j0.posForm  & idx.i != j0.negForm & idx.j == j0.posForm ||
+           idx.j != j0.posForm  & idx.j != j0.negForm & idx.i == j0.negForm)
+          m(idx) + c
+        else if (idx.i == j0.posForm & idx.j == j0.negForm)
+          m(idx) - (c._x_2)
+        else if (idx.i == j0.negForm & idx.j == j0.posForm)
+          m(idx) + (c._x_2)
+        else
+          m(idx))
+
+
+
+  def assign_vj0_gets_minus_vj0(j0 : Var) : Octagon[N] =
+    // Case 4. Mine' 2006 fig. 15 p. 35
+    // {{ Vj0 <- -Vj0 }}
+    preserveClosure(
+      // Invertible assignments do not require strongly closed
+      // matrix arguments but preserve the strong closure (Mine'
+      // 2006 p. 34)
+      (m : DBM[N]) => (idx : OctIdx) =>
+        if ((Seq(j0.posForm, j0.negForm) contains idx.i) &
+           !(Seq(j0.posForm, j0.negForm) contains idx.j))
+          m(idx.bari)
+        else
+          if (!(Seq(j0.posForm, j0.negForm) contains idx.i) &
+               (Seq(j0.posForm, j0.negForm) contains idx.j))
+          m(idx.barj)
+        else
+          if ((Seq(j0.posForm, j0.negForm) contains idx.i) &
+              (Seq(j0.posForm, j0.negForm) contains idx.j))
+          m(idx.barj.bari)
+        else {
+          require (
+            !(Seq(j0.posForm, j0.negForm) contains idx.i) &
+            !(Seq(j0.posForm, j0.negForm) contains idx.j))
+          m(idx)})
+
+  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+    // Case 3. Mine' 2006 fig. 15 p. 35
+    // {[ Vj0 <- Vi0 + c }}
+    require (j0 != i0)
+    onClosedDBM(
+      closeIncrementally(j0)(
+      // Non invertible assignments [like] Vj0 ← ±Vi0 + [a, b] [...]
+      // require a strongly closed argument due to the embedded
+      // forget operator; [...] can be closed by merely performing
+      // an incremental strong closure with respect to the assigned
+      // variable Vj0 (Mine' 2006 p.36).
+      (m : ClosedDBM[N]) => (idx : OctIdx) =>
+        if (idx.i == j0.posForm & idx.j == i0.posForm
+          | idx.i == i0.negForm  & idx.j == j0.negForm)
+          -c
+        else
+          if (idx.i == i0.posForm & idx.j == j0.posForm
+            | idx.i == j0.negForm  & idx.j == i0.negForm)
+          c
+        else
+          forget_f(m)(j0)(idx)))}
+
+  /////////////////////////////////////
+
+  /**
+    *  The indices *look* swapped here but are not.  Cfr Mine 2006
+    *  p.7, "the element at line i, column j, where 1 ≤ i ≤ n, 1 ≤ j ≤
+    *  n, denoted by mij equals c ∈ I if there is a constraint of the
+    *  form Vj − Vi ≤ c ..."
+    */
+  def get_ineq_vi_minus_vj_leq_c(j : SignedVarIdx, i : SignedVarIdx) : Option[N] = closedDbm.map(_(DBMIdx(i.i, j.i)))
+
+  def isEmpty = isBottom
+
+  def isBottom = closedDbm match {
+    case Some(_) => false
+    case None => true
+  }
+
+  def isTop = closedDbm.map(_.isTop) match {
+    case Some(t) => t
+    case None => false
+  }
+
+  def dimension : OctagonDim
+
+  def union(that : Octagon[N]) : Octagon[N] = {
+    that match {
+      case bot : BottomOctagon[N] => { assert (bot.dimension == this.dimension); this }
+      case o : OptimizedOctagon[N] => { assert (o.dimension == this.dimension);
+        o.closedDbm match {
+          case Some(them) =>
+            this.closedDbm match {
+              case Some(us) => yieldClosed(us union them)
+              // Result of union of two closed DBMs is closed (Mine' 2006 Fig. 27 p. 54)
+              case None => BottomOctagon[N](this.dimension)
+            }
+          case _ => BottomOctagon[N](this.dimension)
+        }
+      }
+      case _ => ??? // Not implemented
+    }
+  }
+
+  def intersection(that : Octagon[N]) : Octagon[N] = {
+    that match {
+      case bot : BottomOctagon[N] => { assert (bot.dimension == this.dimension); that }
+      case o : OptimizedOctagon[N] => { assert (o.dimension == this.dimension);
+        yieldNonClosed(o.anyDbm.intersection(this.anyDbm))
+        // Closure is not guaranteed even if operands are closed,
+      }
+      case _ => ??? // Not implemented
+    }
+  }
+
+  def widening(that : Octagon[N]) : Octagon[N] =
+    if (that.isBottom)
+      this
+    else
+      that match {
+        case bot : BottomOctagon[N] => this
+        case o   : OptimizedOctagon[N] =>
+          this.closedDbm.flatMap(us =>
+            o.closedDbm.map(
+              them =>
+              us.combine((us, them) =>
+                if (us > them) us
+                else ifield.PositiveInfinity)(them))) match {
+            case None => BottomOctagon(dimension)
+            case Some(dbm) => yieldNonClosed(dbm) // TODO: Is this guaranteed closed already?
+          }
+      }
+
+  def narrowing(that : Octagon[N]) : Octagon[N] =
+    if (that.isBottom)
+      that
+    else
+      that match {
+        case bot : BottomOctagon[N] => that
+        case o   : OptimizedOctagon[N] =>
+          this.closedDbm.flatMap(us =>
+            o.closedDbm.map(
+              them =>
+              us.combine((us, them) =>
+                if (us == ifield.PositiveInfinity) them
+                else us)(them))) match {
+            case None => BottomOctagon(dimension)
+            case Some(dbm) => yieldNonClosed(dbm) // TODO: Is this guaranteed closed already?
+          }
+     }
+
+
+
+
+  ////////////////////////////////////////
+
+  def tryCompareTo[B >: Octagon[N]](other: B)(implicit arg0: (B) => PartiallyOrdered[B]): Option[Int] = {
+    this.closedDbm match {
+      case Some(us) => other match {
+        case _ : BottomOctagon[N] => Some(1) // They're bottom, we're greater
+        case o : OptimizedOctagon[N] => o.closedDbm match {
+          case Some(them) => us.tryCompareTo(them)
+          case None => Some(1) // They're bottom, we're greater
+        }
+        //// Additional case for comparing with SimpleOctagons
+        // case s : simple.SimpleOctagon[N] => us.tryCompareTo(s.m)
+        ////
+        case _ => ??? // Not impl
+      }
+      case None => other match {
+        case _ : BottomOctagon[N] => Some(0) // They're bottom,
+                                             // we're also bottom
+        case o : OptimizedOctagon[N] => o.closedDbm match {
+          case Some(them) => Some(-1) // They're greater, we're
+                                      // bottom
+          case None => Some(0)        // Both bottom
+        }
+        //// Additional case for comparing with SimpleOctagons
+        // case s : simple.SimpleOctagon[N] => Some(-1) // They're a
+                                                        // closed
+                                                        // non-bottom
+                                                     // DBM, we
+                                                     // are
+                                                     // bottom
+        case _ => ??? // Not impl
+      }
+    }
+  }
+}

--- a/core/src/main/scala/it/unich/jandom/ui/NumericalDomains.scala
+++ b/core/src/main/scala/it/unich/jandom/ui/NumericalDomains.scala
@@ -34,7 +34,8 @@ object NumericalDomains extends ParameterEnumeration[NumericalDomain] {
     ParameterValue(BoxDoubleDomain(overReals=true), "BoxDouble over Reals", "This is a native Scala implementation of boxes. It is safe " +
       "w.r.t. reals."),
     ParameterValue(ParallelotopeRationalDomain(), "Parallelotope over Rationals", "This is a native Scala implementation of parallelotopes using rational numbers."),
-    ParameterValue(SumBoxDoubleParallelotopeRationDomain(), "BoxDouble + ParallelotopeRational", "Sum of boxes and parallelotopes.")
+    ParameterValue(SumBoxDoubleParallelotopeRationDomain(), "BoxDouble + ParallelotopeRational", "Sum of boxes and parallelotopes."),
+    ParameterValue(OctagonDomain(), "Octagon Domain", "foo")
   )
   val default = values.last
 

--- a/core/src/main/scala/it/unich/jandom/ui/NumericalDomains.scala
+++ b/core/src/main/scala/it/unich/jandom/ui/NumericalDomains.scala
@@ -42,7 +42,5 @@ object NumericalDomains extends ParameterEnumeration[NumericalDomain] {
   // Load objects PPLUIInitializer and PPLMacroUIInitializer if available
   Try ( Class.forName ("it.unich.jandom.ui.PPLUIInitializer$") )
   Try ( Class.forName ("it.unich.jandom.ui.PPLMacroUIInitializer$") )
-
-  // TODO
   Try ( Class.forName ("it.unich.jandom.ui.ApronUIInitializer$") )
 }

--- a/core/src/main/scala/it/unich/jandom/ui/NumericalDomains.scala
+++ b/core/src/main/scala/it/unich/jandom/ui/NumericalDomains.scala
@@ -41,4 +41,7 @@ object NumericalDomains extends ParameterEnumeration[NumericalDomain] {
   // Load objects PPLUIInitializer and PPLMacroUIInitializer if available
   Try ( Class.forName ("it.unich.jandom.ui.PPLUIInitializer$") )
   Try ( Class.forName ("it.unich.jandom.ui.PPLMacroUIInitializer$") )
+
+  // TODO
+  Try ( Class.forName ("it.unich.jandom.ui.ApronUIInitializer$") )
 }

--- a/core/src/main/scala/it/unich/jandom/utils/dbm/DBM.scala
+++ b/core/src/main/scala/it/unich/jandom/utils/dbm/DBM.scala
@@ -1,0 +1,161 @@
+/**
+  * Copyright 2018 Filippo Sestini, Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty ofa
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.utils.dbm
+import it.unich.jandom.utils.numberext.IField
+import it.unich.jandom.utils.numberext.StaticIField
+import scala.reflect.ClassTag
+
+//////////////////////
+// Utils
+//////////////////////
+
+case class DBMIdx(val i : Int, val j : Int) {
+  require(i != 0)
+  require(j != 0) // Mine' counts from 1, see e.g. fig 4.4 p 120
+  private def bar(i: Int) = if (i % 2 == 0) i - 1 else i + 1 // Mine' 2006 counts indices from 1
+  def diagonal : Boolean = (i == j)
+  def bari = DBMIdx(bar(i), j)
+  def barj = DBMIdx(i, bar(j))
+}
+
+case class DBMDim(private val n : Int) {
+  require(n != 0)
+  require(n % 2 == 0)
+  def grid : Seq[Seq[DBMIdx]] = (1 to n).map(i => (1 to n).map(j => DBMIdx(i,j)))
+  def allIdxs : Seq[DBMIdx] = grid.flatten
+  def diagonalIdxs : Seq[DBMIdx] = (1 to n).map(i => DBMIdx(i,i))
+  def dbmDimToInt : Int = n
+}
+
+//////////////////////
+// DBM
+//////////////////////
+
+/**
+  * A matrix-based DBM.
+  *
+  * "matrix-based" means that \bot is explicitly not represented (in
+  * practice, Option[DBM] with None where \bot would be makes more
+  * sense in terms of readability in the client classes)
+  */
+trait DBM[N <: IField[N]] {
+
+  def isTop : Boolean
+
+  def dimension : DBMDim
+
+  def updated(idx : DBMIdx)(n : N) : DBM[N]
+
+  protected def isClosed = false
+
+  /**
+    * Unlike union, the result of an intersection is seldom closed
+    * (see Mine' 2006 p. 68)
+    */
+  def intersection (that : DBM[N]) : DBM[N] = {
+    that match {
+      case that : DBM[N] => this.combine(_.min(_))(that)
+      case _ => ???
+    }
+  }
+
+  def combine(f: (N, N) => N)(mb: DBM[N]): DBM[N]
+
+  def apply(i : DBMIdx) : N
+
+  def all : Seq[(DBMIdx, N)]
+
+  def map[A](f : N => A) : Seq[A]
+  import scala.collection.immutable.StringOps
+  override def toString : String =
+    (if (this.isClosed) "Closed" else "") +
+      "DBM(dim = " + dimension + ", mat = \n "+
+  dimension.grid.map(row => row.map(idx =>
+    this(idx).toString.take(5).padTo(5," ").mkString("")
+
+  )
+        .mkString("\t"))
+      .mkString("\n")
+
+  def canEqual(a: Any) = a.isInstanceOf[DBM[N]]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: DBM[N] => {
+        if (that.dimension == this.dimension)
+          if (that.isClosed == this.isClosed)
+            (dimension.allIdxs.forall(idx => that(idx) == this(idx)))
+          else
+            false
+          else
+            false
+      }
+      case _ => false
+    }
+
+  override def hashCode : Int = ???
+}
+
+
+trait ClosedDBM[N <: IField[N]] extends DBM[N] with PartiallyOrdered[ClosedDBM[N]] {
+  /**
+    * The union of closed DBM yields a closed DBM;
+    * Figure 11 in Mine' 2006 p. 26;
+    */
+  def union(that : ClosedDBM[N]) : DBM[N] = {
+    that match {
+      // yields a closed DBM .get is therefore safe
+      case that : ClosedDBM[N] => this.combine(_.max(_))(that)
+      case _ => ???
+    }
+  }
+
+  override def isClosed = true
+
+  def tryCompareTo[B >: ClosedDBM[N]](other : B)(implicit arg0: (B) => PartiallyOrdered[B]) : Option[Int] =
+    other match {
+      case that : ClosedDBM[N] => {
+        require(that.dimension == this.dimension)
+        if (dimension.allIdxs.forall(idx => that(idx) == this(idx))) Some(0)
+        else if (dimension.allIdxs.forall(idx => this(idx) <= that(idx))) Some(-1) // We have tighter bounds
+        else if (dimension.allIdxs.forall(idx => this(idx) >= that(idx))) Some(1) // They have tighter bounds
+        else None
+      }
+      // We can't say anything until we close
+      case _ => ??? // Option.empty
+    }
+}
+
+trait DBMFactory[N <: IField[N]] {
+
+  val ifield : StaticIField[N]
+
+  def top(d : DBMDim) : ClosedDBM[N] = {
+    markAsClosed(fromFun(d,
+      idx => if (idx.diagonal) ifield.zero else ifield.PositiveInfinity
+    ))
+  }
+
+  def fromFun(d : DBMDim, f : DBMIdx => N) : DBM[N]
+
+  /**
+    * This is for use ONLY by ourselves and Closure
+    */
+  protected[dbm] def markAsClosed(d : DBM[N]) : ClosedDBM[N]
+}

--- a/core/src/main/scala/it/unich/jandom/utils/dbm/DBM.scala
+++ b/core/src/main/scala/it/unich/jandom/utils/dbm/DBM.scala
@@ -82,7 +82,6 @@ trait DBM[N <: IField[N]] {
   def all : Seq[(DBMIdx, N)]
 
   def map[A](f : N => A) : Seq[A]
-  import scala.collection.immutable.StringOps
   override def toString : String =
     (if (this.isClosed) "Closed" else "") +
       "DBM(dim = " + dimension + ", mat = \n "+

--- a/core/src/main/scala/it/unich/jandom/utils/dbm/DBMClosure.scala
+++ b/core/src/main/scala/it/unich/jandom/utils/dbm/DBMClosure.scala
@@ -1,0 +1,128 @@
+/**
+  * Copyright 2017 Filippo Sestini, Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty ofa
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.utils.dbm
+import it.unich.jandom.utils.numberext.IField
+import it.unich.jandom.utils.numberext.StaticIField
+
+/**
+  * An implementation of the modified Floyd-Warshall algorithm found
+  * in Mine' 2006 figure 9 p. 20, which computes the strong closure of
+  * a DBM.
+  */
+class MineFloydWarshall[N <: IField[N]](implicit ifield: StaticIField[N], val d : DBMFactory[N]) {
+
+  import scala.language.implicitConversions
+
+  ////////////////
+  // Begin sugar
+  ////////////////
+
+  import it.unich.jandom.domains.numerical.octagon.SignedVarIdx
+  import it.unich.jandom.domains.numerical.octagon.VPlusIdx
+  import it.unich.jandom.domains.numerical.octagon.VMinusIdx
+  import it.unich.jandom.domains.numerical.octagon.Var
+
+  implicit def signedvartoint(i : SignedVarIdx) : Int =
+    i match {
+      case VPlusIdx(i) => i
+      case VMinusIdx(i) => i
+      case _ => ???
+    }
+
+  implicit def inttovar(i : Int) : Var = Var(i)
+
+  ////////////////
+  // End sugar
+  ////////////////
+
+
+  def stronglyClosed (n : DBMDim)(f : DBMIdx => N): Option[ClosedDBM[N]] =
+    strongClosure(
+      d.fromFun(n,f)
+    )
+
+
+  def strongClosure (m: DBM[N]): Option[ClosedDBM[N]] = {
+    val n2 = m.dimension.dbmDimToInt
+    val n = n2 / 2
+
+    def step1(k : Int, n2 : Int, m : DBM[N]) = {
+      (1 to n2).flatMap(
+        i =>
+        (1 to n2).map(
+          j => (Var(k), SignedVarIdx(i), SignedVarIdx(j))
+        )
+      ).foldRight(m)(closeIter)
+    }
+
+    def strengtheningStep(n2 : Int, m : DBM[N]) = {
+      (1 to n2).flatMap(
+        i =>
+        (1 to n2).map(
+          j => (SignedVarIdx(i), SignedVarIdx(j))
+        )
+      ).foldRight(m)(strengthenIter)
+    }
+
+    emptinessCheck(
+      (1 to n).foldRight(m)(
+        (k, m) => strengtheningStep(n2, step1(k, n2, m))
+      )).map(markAsClosed(_))
+  }
+
+
+
+  protected def closeIter (kij : (Var, SignedVarIdx, SignedVarIdx), m : DBM[N]) = {
+    val k = kij._1
+    val i = kij._2
+    val j = kij._3
+    m.updated(DBMIdx(i, j))(
+      m(DBMIdx(i, j)).min(
+        m(DBMIdx(i, k.posForm)) + m(DBMIdx(k.posForm, j))).min(
+        m(DBMIdx(i, k.negForm)) + m(DBMIdx(k.negForm, j))).min(
+        m(DBMIdx(i, k.posForm)) + m(DBMIdx(k.posForm, k.negForm)) + m(DBMIdx(k.negForm, j))).min(
+        m(DBMIdx(i, k.negForm)) + m(DBMIdx(k.negForm, k.posForm)) + m(DBMIdx(k.posForm, j)))
+    )
+  }
+
+  protected def strengthenIter (ij : (SignedVarIdx, SignedVarIdx), m : DBM[N]) : DBM[N] = {
+      val i = ij._1
+    val j = ij._2
+
+      m.updated(DBMIdx(i, j))(
+        m(DBMIdx(i, j)).min(
+          (m(DBMIdx(i, i).barj) + m(DBMIdx(j, j).bari))._div_2))
+  }
+
+  protected def emptinessCheck(m: DBM[N]): Option[DBM[N]] = {
+    if (m.all.exists((pair : (DBMIdx, N)) => pair._1.diagonal & pair._2 < ifield.zero))
+      None
+    else {
+      val updater: DBMIdx => N =
+        (idx =>
+          if (idx.diagonal)
+            ifield.zero
+          else
+            m(idx))
+      Some(d.fromFun(m.dimension, updater))
+    }
+  }
+  def makeClosed(n : DBMDim)(f : DBMIdx => N) : ClosedDBM[N] = d.markAsClosed(d.fromFun(n, f))
+  def markAsClosed(dbm : DBM[N]) : ClosedDBM[N] = d.markAsClosed(dbm)
+}

--- a/core/src/main/scala/it/unich/jandom/utils/numberext/IField.scala
+++ b/core/src/main/scala/it/unich/jandom/utils/numberext/IField.scala
@@ -1,0 +1,44 @@
+/**
+  * Copyright 2018 Filippo Sestini, Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty ofa
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.utils.numberext
+
+trait IField[N] {
+  def +(that : N) : N
+  def -(that : N) : N
+  def min(that : N) : N
+  def max(that : N) : N
+  def isPosInfinity : Boolean
+  def isNegInfinity : Boolean
+  def compare(that: N) : Int
+  def >(that: N) : Boolean
+  def >=(that: N) : Boolean
+  def <(that: N): Boolean
+  def <=(that: N): Boolean
+  // def !=(that: N): Boolean
+  def /(that: N): N
+  def unary_- : N
+  def _x_2 : N
+  def _div_2 : N
+}
+
+trait StaticIField[F <: IField[F]] {
+  def zero : F
+  def PositiveInfinity : F
+  def NegativeInfinity : F
+}

--- a/core/src/main/scala/it/unich/jandom/utils/numberext/RationalExt.scala
+++ b/core/src/main/scala/it/unich/jandom/utils/numberext/RationalExt.scala
@@ -38,7 +38,7 @@ import scala.runtime.RichDouble
  * @param special one of the values in the RationalExt enumeration. They are `NORMAL`, `POSINF`,
  * `NEGINF` and `NAN`, with the obvious meaning.
  */
-class RationalExt(val value: Rational, private val special: RationalExt.SpecialValue.SpecialValue) extends ScalaNumber with ScalaNumericConversions {
+class RationalExt(val value: Rational, private val special: RationalExt.SpecialValue.SpecialValue) extends ScalaNumber with ScalaNumericConversions with IField[RationalExt] {
 
   import RationalExt.SpecialValue._
 
@@ -236,9 +236,19 @@ class RationalExt(val value: Rational, private val special: RationalExt.SpecialV
     case NEGINF => "-Infinity"
     case NAN => "NaN"
   }
+
+  def _div_2 : RationalExt =
+    if (isPosInfinity) this
+    else if (isNegInfinity) this
+    else (this / 2)
+
+  def _x_2 : RationalExt =
+    if (isPosInfinity) this
+    else if (isNegInfinity) this
+    else (this * 2)
 }
 
-object RationalExt {
+object RationalExt extends StaticIField[RationalExt]{
   /**
    * The enumeration of the special values for the `RationalExt` class.
    */

--- a/core/src/test/apron/it/unich/jandom/domains/numerical/apron/ApronSpecification.scala
+++ b/core/src/test/apron/it/unich/jandom/domains/numerical/apron/ApronSpecification.scala
@@ -28,10 +28,10 @@ import it.unich.jandom.utils.numberext.RationalExt
 import scala.language.reflectiveCalls
 
 class ApronSpecification extends PropSpec with PropertyChecks {
-  import it.unich.jandom.domains.numerical.apron.Utils.Ints._
-  import it.unich.jandom.domains.numerical.apron.Utils.Rationals._
-  import it.unich.jandom.domains.numerical.apron.Utils.RationalExts._
-  import it.unich.jandom.domains.numerical.apron.Utils.LinearForms._
+  import it.unich.jandom.domains.numerical.Utils.Ints._
+  import it.unich.jandom.domains.numerical.Utils.Rationals._
+  import it.unich.jandom.domains.numerical.Utils.RationalExts._
+  import it.unich.jandom.domains.numerical.Utils.LinearForms._
 
   val apronDomain = ApronIntOctagonDomain()
   ///////////////////////////////////////////////////////

--- a/core/src/test/apron/it/unich/jandom/domains/numerical/apron/ApronSpecification.scala
+++ b/core/src/test/apron/it/unich/jandom/domains/numerical/apron/ApronSpecification.scala
@@ -1,0 +1,166 @@
+/**
+  * Copyright 2018 Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of a
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.domains.numerical.apron
+import it.unich.jandom.domains.numerical._
+import org.scalatest.PropSpec
+import org.scalatest.prop.PropertyChecks
+import org.scalacheck.Gen
+import spire.math.Rational
+import it.unich.jandom.domains.numerical._
+import it.unich.jandom.domains.numerical.LinearForm
+import it.unich.jandom.utils.numberext.RationalExt
+import scala.language.reflectiveCalls
+
+class ApronSpecification extends PropSpec with PropertyChecks {
+  import it.unich.jandom.domains.numerical.apron.Utils.Ints._
+  import it.unich.jandom.domains.numerical.apron.Utils.Rationals._
+  import it.unich.jandom.domains.numerical.apron.Utils.RationalExts._
+  import it.unich.jandom.domains.numerical.apron.Utils.LinearForms._
+
+  val apronDomain = ApronIntOctagonDomain()
+  ///////////////////////////////////////////////////////
+  // Properties of representation-converting helpers
+  ///////////////////////////////////////////////////////
+
+  property("coeffToRational . rationalToCoeff == id") {
+    forAll {
+      (r: Rational)
+      =>
+      assert(SpireGmpUtils.unsafeCoeffToRational(SpireGmpUtils.rationalToCoeff(r)) == r)
+    }
+  }
+
+  property("scalarToRatExt . ratExtToScalar == id") {
+    forAll {
+      (r: RationalExt)
+      =>
+      assert(SpireGmpUtils.scalarToRatExt(SpireGmpUtils.ratExtToScalar(r)) == r)
+    }
+  }
+
+  property("linexprToLf . lfToLinexpr == id") {
+    forAll {
+      (r: LinearForm)
+      =>
+      assert(SpireGmpUtils.linexprToLf(SpireGmpUtils.lfToLinexpr(r)) == r)
+    }
+  }
+
+  ///////////////////////////////////////////////////////
+  // Basic properties of Apron octagons
+  ///////////////////////////////////////////////////////
+
+
+  property("top.isTop") {
+    forAll (GenTinyPosInt){
+      n : Int
+      =>
+      val top = apronDomain.top(n)
+      assert (top.isTop)
+    }
+  }
+
+  property("bottom.isBottom") {
+    forAll (GenTinyPosInt){
+      n : Int
+      =>
+      val bottom = apronDomain.bottom(n)
+      assert (bottom.isBottom)
+    }
+  }
+
+  property("T U T = T & T U _|_ = T") {
+    forAll (GenTinyPosInt){
+      n : Int
+      =>
+      val top = apronDomain.top(n)
+      val bottom = apronDomain.bottom(n)
+      assert (top.union(top) == top)
+      assert (bottom.union(top) == top)
+    }
+  }
+
+  property("T /\\ _|_ = _|_ & _|_ /\\ _|_ = _|_") {
+    forAll (GenTinyPosInt){
+      n : Int
+      =>
+      val top = apronDomain.top(n)
+      val bottom = apronDomain.bottom(n)
+      assert (bottom.intersection(bottom) == bottom)
+      assert (top.intersection(bottom) == bottom)
+    }
+  }
+
+  property("T U _|_ >= _|_ & T /\\ _|_ =< T") {
+    forAll (GenTinyPosInt){
+      n : Int
+      =>
+      val top = apronDomain.top(n)
+      val bottom = apronDomain.bottom(n)
+      assert (bottom.union(top) > bottom)
+      assert (top.union(bottom) > bottom)
+      assert (bottom.intersection(top) < top)
+      assert (top.intersection(bottom) < top)
+      assert (bottom.union(top) >= bottom)
+      assert (top.union(bottom) >= bottom)
+      assert (bottom.intersection(top) <= top)
+      assert (top.intersection(bottom) <= top)
+    }
+  }
+
+  property("T != _|_, T !< T, _|_ !< _|_") {
+    forAll (GenTinyPosInt){
+      n : Int
+      =>
+      val top = apronDomain.top(n)
+      val bottom = apronDomain.bottom(n)
+      assert (!(top == bottom))
+      assert (!(bottom == top))
+      assert (!(top > top))
+      assert (!(top < top))
+      assert (!(bottom < bottom))
+      assert (!(bottom > bottom))
+    }
+  }
+
+  property("_|_ <= T.{x <- c} <= T ") {
+    import org.scalacheck.Shrink
+    implicit val noShrink: Shrink[Int] = Shrink.shrinkAny
+    forAll (Gen.choose(1, 50)){
+      n
+      =>
+      forAll (Gen.posNum[Int]){
+        ip
+        =>
+        forAll (Gen.choose(0, n)) {
+          x : Int =>
+          val i = ip%n
+          val top = apronDomain.top(n)
+          val bottom = apronDomain.bottom(n)
+          val lf = LinearForm.c(spire.math.Rational(x,1))
+          val updated = top.linearAssignment(i, lf)
+          assert((updated.toInterval).low(i) == x)
+          assert((updated.toInterval).high(i) == x)
+          assert(updated <= top)
+          assert(bottom <= updated)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/apron/it/unich/jandom/domains/numerical/apron/ApronSuite.scala
+++ b/core/src/test/apron/it/unich/jandom/domains/numerical/apron/ApronSuite.scala
@@ -1,0 +1,50 @@
+/**
+  * Copyright 2018 Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of a
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+
+package it.unich.jandom.domains.numerical.apron
+import it.unich.jandom.domains.numerical._
+import org.scalatest.FunSuite
+
+class ApronSuite extends FunSuite {
+  val dom = ApronIntOctagonDomain()
+
+  test ("linearAssignment sanity check") {
+    val top = dom.top(4)
+    val lf = new DenseLinearForm(Seq(1,1,0,0,0))
+    assert (lf.known == 1)
+    val foo = top.linearInequality(lf)
+    assert(foo.constraints.toSet == Seq(lf).toSet)
+  }
+
+  test ("linearInequality -1 sanity check") {
+    val top = dom.top(4)
+    val lf = new DenseLinearForm(Seq(-1,1,0,0,0))
+    assert (lf.known == -1)
+    val foo = top.linearInequality(lf)
+    assert(foo.constraints.toSet == Seq(lf).toSet)
+  }
+
+  test ("linearInequality -2 sanity check") {
+    val top = dom.top(4)
+    val lf = new DenseLinearForm(Seq(2,-1,0,0,0))
+    assert (lf.known == 2)
+    val foo = top.linearInequality(lf)
+    assert(foo.constraints.toSet == Seq(lf).toSet)
+  }
+}

--- a/core/src/test/apron/it/unich/jandom/domains/numerical/apron/MetaSpecification.scala
+++ b/core/src/test/apron/it/unich/jandom/domains/numerical/apron/MetaSpecification.scala
@@ -23,7 +23,7 @@ import org.scalatest.prop.PropertyChecks
 import spire.math.Rational
 
 class MetaSpecification extends PropSpec with PropertyChecks {
-  import it.unich.jandom.domains.numerical.apron.Utils
+  import it.unich.jandom.domains.numerical.Utils
   import Utils._
   import Rationals._
   import Rationals.arbRational

--- a/core/src/test/apron/it/unich/jandom/domains/numerical/apron/MetaSpecification.scala
+++ b/core/src/test/apron/it/unich/jandom/domains/numerical/apron/MetaSpecification.scala
@@ -1,0 +1,54 @@
+/**
+  * Copyright 2017 Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of a
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.domains.numerical.apron
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.PropSpec
+import org.scalatest.prop.PropertyChecks
+import spire.math.Rational
+
+class MetaSpecification extends PropSpec with PropertyChecks {
+  import it.unich.jandom.domains.numerical.apron.Utils
+  import Utils._
+  import Rationals._
+  import Rationals.arbRational
+
+  /*
+   * Checks on the sanity of test utils themselves
+   */
+  property("Check that GenGreaterRat consistently yields greater rationals") {
+    forAll(arbitrary[Rational]) {
+      r : Rational =>
+      forAll(GenGreaterRat(r)) {
+        gen =>
+        assert(r < gen)
+      }
+    }
+  }
+
+  property("Check that GenSmallerRat consistently yields smaller rationals") {
+    forAll(arbitrary[Rational]) {
+      r : Rational =>
+      forAll(GenSmallerRat(r)) {
+        gen =>
+        assert(r > gen)
+      }
+    }
+  }
+
+}

--- a/core/src/test/apron/it/unich/jandom/domains/numerical/apron/Utils.scala
+++ b/core/src/test/apron/it/unich/jandom/domains/numerical/apron/Utils.scala
@@ -1,0 +1,162 @@
+package it.unich.jandom.domains.numerical.apron
+import it.unich.jandom.domains.numerical._
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen.Choose
+import org.scalacheck.Gen
+import spire.math.Rational
+import it.unich.jandom.utils.numberext.RationalExt
+
+object Utils {
+  val kTinyPosInt = 5
+  val kTinyNegInt = -5
+  val kMediumPosInt = 2^5
+  val kMediumNegInt = -2^5
+  val kLargePosInt = Int.MaxValue / (2^5)
+  val kLargeNegInt = Int.MinValue / (2^5)
+  val kLargestPosInt = Int.MaxValue
+  val kLargerstNegInt = Int.MinValue
+
+  object Ints {
+    def GenTinyInt : Gen[Int] = Gen.choose(kTinyNegInt, kTinyPosInt)
+    def GenTinyPosInt : Gen[Int] = Gen.choose(1, kTinyPosInt)
+    def GenMediumInt : Gen[Int] = Gen.choose(kMediumNegInt, kMediumPosInt)
+  }
+
+  object Rationals {
+
+    def GenRational: Gen[Rational] =
+      for {
+        n <- Gen.choose(kMediumNegInt, kMediumPosInt)
+        d <- Gen.choose(kMediumNegInt, kMediumPosInt).suchThat(_ != 0)
+      } yield {
+        Rational(n, d)
+      }
+
+    def GenPosRational: Gen[Rational] =
+      for {
+        n <- Gen.choose(1, kMediumPosInt)
+        d <- Gen.choose(1, kMediumPosInt)
+      } yield {
+        Rational(n, d)
+      }
+
+
+    def GenRationalInterval : Gen[(Rational, Rational)] = for {
+      a <- GenRational
+      b <- GenRational
+    } yield if (a <= b)
+      (a, b)
+    else (b, a)
+
+    implicit object chooseRat extends Choose[Rational] {
+      def choose(min: Rational, max: Rational): Gen[Rational] = {
+        assert(min.denominator > 0)
+        assert(max.denominator > 0)
+        assert(min <= max)
+        val lcm = spire.math.lcm(min.denominator, max.denominator)
+        // Careful with overflows here
+        val commonden = lcm
+        val minnum = min.numerator * (max.denominator / lcm)
+        val maxnum = max.numerator * (min.denominator / lcm)
+        assert(Rational(minnum, commonden) == min)
+        assert(Rational(maxnum, commonden) == max)
+        assert(minnum <= maxnum)
+        Gen.choose[Long](minnum.toLong, maxnum.toLong).map(n => Rational(n, commonden))
+      }
+    }
+
+    implicit def arbRational: Arbitrary[Rational] =
+      Arbitrary {
+        GenRational
+      }
+
+
+    def GenGreaterRat(r : Rational) = {
+      val arbnum = r.numerator * kMediumPosInt + 1 //arbitrary
+      val arbden = r.denominator * kMediumPosInt //arbitrary
+      val lower = Rational(arbnum, arbden)
+      assert(lower > r)
+      Gen.choose[Rational](lower, (lower + kMediumPosInt))
+    }
+
+    def GenSmallerRat(r : Rational) = {
+      val arbnum = r.numerator * kMediumPosInt - 1 //arbitrary
+      val arbden = r.denominator * kMediumPosInt //arbitrary
+      val upper = Rational(arbnum, arbden)
+      assert(upper < r)
+      Gen.choose[Rational]((upper - kMediumPosInt), upper)
+    }
+  }
+
+  object RationalExts {
+    def GenFiniteRationalExt = for (a <- Rationals.GenRational) yield RationalExt(a)
+    def GenFiniteRationalExtOrInf(pInf: Int = 10, pMinusInf: Int = 0) : Gen[RationalExt] = {
+      assert(pInf >= 0)
+      assert(pInf <= 100)
+      assert(pMinusInf >= 0)
+      assert(pMinusInf <= 100)
+      assert(pMinusInf + pInf <= 100)
+      Gen.frequency(
+        (pInf, Gen.const(RationalExt.PositiveInfinity)),
+        (pMinusInf, Gen.const(RationalExt.NegativeInfinity)),
+        (100 - pInf - pMinusInf, GenFiniteRationalExt)
+      )
+    }
+
+    implicit def arbRationalExt : Arbitrary[RationalExt] = Arbitrary { GenFiniteRationalExtOrInf(5, 5) }
+
+    def GenFiniteRationalExtInterval : Gen[(RationalExt, RationalExt)] = for {
+      a <- GenFiniteRationalExt
+      b <- GenFiniteRationalExt
+    } yield if (a <= b)
+      (a, b)
+    else (b, a)
+
+    def GenRationalExtInterval(pInf: Int = 5, pMinusInf: Int = 5) : Gen[(RationalExt, RationalExt)] = for {
+      a <- GenFiniteRationalExtOrInf(pInf, pMinusInf)
+      b <- GenFiniteRationalExtOrInf(pInf, pMinusInf)
+    } yield if (a <= b)
+      (a, b)
+    else (b, a)
+  }
+
+  object LinearForms {
+    def GenLfAnyDim : Gen[LinearForm] = for {
+      n <- Gen.choose(1,kTinyPosInt)
+      lf <- GenLf(n)
+    } yield lf
+
+    def GenLf(n:Int) : Gen[LinearForm] =
+      for {
+        coef <- Gen.containerOfN[Seq, Rational](n, Rationals.GenRational)
+      } yield LinearForm(coef :_*)
+
+    def GenExactLf(n: Int): Gen[LinearForm] = for
+    {
+      c <- Gen.choose(kMediumNegInt, kMediumPosInt)
+      vi <- Gen.choose(1, n)
+      ci <- Gen.oneOf(+1, -1)
+      vj <- Gen.choose(1, n)
+      cj <- Gen.oneOf(+1, -1) // TODO This can potentially overwrite vi, which is as intended since this yields the 1-coeff case, TODO: require different
+    } yield new DenseLinearForm(
+      Array.fill[Rational](n+1)(0)
+        .updated(0, Rational(c))
+        .updated(vi, Rational(ci))
+        .updated(vj, Rational(cj))
+        .toSeq
+    )
+    implicit def arbLinearForm: Arbitrary[LinearForm] =
+      Arbitrary { GenLfAnyDim }
+
+    def GenIntLfAnyDim : Gen[LinearForm] = for {
+      n <- Gen.choose(1,kTinyPosInt)
+      lf <- GenIntLf(n)
+    } yield lf
+
+    def GenIntLf(n:Int) : Gen[LinearForm] =
+      for {
+        coef <- Gen.containerOfN[Seq, Rational](n, Gen.choose[Int](kMediumNegInt, kMediumPosInt).map(Rational(_)))
+      } yield LinearForm(coef :_*)
+  }
+}

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/BisimulationOctagonSpecification.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/BisimulationOctagonSpecification.scala
@@ -1,0 +1,150 @@
+/**
+  * Copyright 2018 Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of a
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.domains.numerical
+import it.unich.jandom.domains.numerical.octagon._
+import it.unich.jandom.domains.numerical.octagon.simple._
+import org.scalatest.PropSpec
+import org.scalatest.prop.PropertyChecks
+import it.unich.jandom.utils.numberext.RationalExt
+
+/**
+ * This test checks that the "simple" octagon behaves like the
+ * "optimized" octagon on a sequence of assignments and tests and that
+ * the latter is overapproximated by boxes.
+ */
+
+// TODO: Extend to union, widening and intersection operations
+
+class BisimulationOctagonSpecification extends PropSpec with PropertyChecks {
+  import it.unich.jandom.domains.numerical.Utils.Ints._
+  implicit val boxDomain : BoxRationalDomain = BoxRationalDomain()
+
+  class SimpleOctagonDomain(boxDomain : BoxGenericDomain[RationalExt]) extends OctagonDomain(boxDomain) {
+    implicit val okt : OctagonDomain = this
+    override def top(dim : Int) : Property = new OctagonProperty(new SimpleOctagon(afac.top((OctagonDim(dim).toDBMDim))))(rext, okt, box)
+    override def bottom(dim : Int): Property = new OctagonProperty(new BottomOctagon(OctagonDim(dim)))(rext, okt, box)
+  }
+
+  val simpleOctDomain = new SimpleOctagonDomain(boxDomain)
+  val octDomain = OctagonDomain()
+
+
+  property("Weak oct-box bisimilarity: oct-T.{ some ops }.toBox <= oct-T.toBox{ some ops }") {
+    forAll(GenTinyPosInt.suchThat(_ > 1)) {
+      n => {
+        forAll(GenTinyPosInt.suchThat(_ > 1)) {
+          l => {
+            import Utils._
+            import OpSequences._
+            forAll(genSeq(n,l)) {
+              opSeq => {
+                val top = octDomain.top(n)
+                val boxtop = boxDomain.top(n)
+                assert(top.toBox <= boxtop)
+                val oct = opSeq.foldLeft(top)((op, p) => applyOp(op)(p))
+                val box = opSeq.foldLeft(boxtop)((op, p) => applyOp(op)(p))
+                assert(oct.toBox <= box, opSeq + " + "  + oct + oct.constraints + oct.toBox + " <= " + box)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+package octagon.optimized {
+  import it.unich.jandom.utils.numberext.IField
+
+  class BisimulationOptimizedOctagonSpecification extends PropSpec with PropertyChecks {
+    import it.unich.jandom.domains.numerical.Utils.Ints._
+    implicit val boxDomain : BoxRationalDomain = BoxRationalDomain()
+
+    class SimpleOctagonDomain(boxDomain : BoxGenericDomain[RationalExt]) extends OctagonDomain(boxDomain) {
+      implicit val okt : OctagonDomain = this
+      override def top(dim : Int) : Property = new OctagonProperty(new SimpleOctagon(afac.top((OctagonDim(dim).toDBMDim))))(rext, okt, box)
+      override def bottom(dim : Int): Property = new OctagonProperty(new BottomOctagon(OctagonDim(dim)))(rext, okt, box)
+    }
+
+    val simpleOctDomain = new SimpleOctagonDomain(boxDomain)
+    val octDomain = OctagonDomain()
+
+
+    def compareOcts[N <: IField[N]] (opt : Octagon[N], simp : Octagon[N]) : Option[Int] = {
+      opt match {
+        case bot : BottomOctagon[N] => bot.tryCompareTo(simp)
+        case opt_ : OptimizedOctagon[N] =>
+          opt_.closedDbm match {
+            case Some(us) => simp match {
+              case _ : BottomOctagon[N] => Some(1) // They're bottom, we're greater
+              case o : OptimizedOctagon[N] => o.closedDbm match {
+                case Some(them) => us.tryCompareTo(them)
+                case None => Some(1) // They're bottom, we're greater
+              }
+              //// Additional case for comparing with SimpleOctagons
+              case s : simple.SimpleOctagon[N] => us.tryCompareTo(s.m)
+              ////
+              case _ => ??? // Not impl
+            }
+            case None => simp match {
+              case _ : BottomOctagon[N] => Some(0) // They're bottom,
+                                                   // we're also bottom
+              case o : OptimizedOctagon[N] => o.closedDbm match {
+                case Some(them) => Some(-1) // They're greater, we're
+                                            // bottom
+                case None => Some(0)        // Both bottom
+              }
+              //// Additional case for comparing with SimpleOctagons
+              case s : simple.SimpleOctagon[N] => Some(-1) // They're a
+                                                           // closed
+                                                           // non-bottom
+                                                           // DBM, we
+                                                           // are
+                                                           // bottom
+              case _ => ??? // Not impl
+            }
+          }
+      }
+    }
+
+    property("oct-simpleoct bisimilarity: oct-T.{ some ops } == simpleoct-T.{ some ops }") {
+      forAll(GenTinyPosInt.suchThat(_ > 1)) {
+        n => {
+          forAll(GenTinyPosInt.suchThat(_ > 1)) {
+            l => {
+              import Utils._
+              import OpSequences._
+              forAll(genSeq(n,l)) {
+                opSeq => {
+                  val top = octDomain.top(n)
+                  val simpletop = simpleOctDomain.top(n)
+                  assert(compareOcts(top.o, simpletop.o) == Some(0))
+                  val oct = opSeq.foldLeft(top)((op, p) => applyOp(op)(p))
+                  val simpleoct = opSeq.foldLeft(simpletop)((op, p) => applyOp(op)(p))
+                  assert(compareOcts(oct.o, simpleoct.o) == Some(0))
+                  assert(oct.constraints == simpleoct.constraints)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/BisimulationOctagonSpecification.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/BisimulationOctagonSpecification.scala
@@ -37,8 +37,8 @@ class BisimulationOctagonSpecification extends PropSpec with PropertyChecks {
 
   class SimpleOctagonDomain(boxDomain : BoxGenericDomain[RationalExt]) extends OctagonDomain(boxDomain) {
     implicit val okt : OctagonDomain = this
-    override def top(dim : Int) : Property = new OctagonProperty(new SimpleOctagon(afac.top((OctagonDim(dim).toDBMDim))))(rext, okt, box)
-    override def bottom(dim : Int): Property = new OctagonProperty(new BottomOctagon(OctagonDim(dim)))(rext, okt, box)
+    override def top(dim : Int) : Property = new OctagonProperty(new SimpleOctagon(factory.top((OctagonDim(dim).toDBMDim))))(ifield, okt, box)
+    override def bottom(dim : Int): Property = new OctagonProperty(new BottomOctagon(OctagonDim(dim)))(ifield, okt, box)
   }
 
   val simpleOctDomain = new SimpleOctagonDomain(boxDomain)
@@ -78,8 +78,8 @@ package octagon.optimized {
 
     class SimpleOctagonDomain(boxDomain : BoxGenericDomain[RationalExt]) extends OctagonDomain(boxDomain) {
       implicit val okt : OctagonDomain = this
-      override def top(dim : Int) : Property = new OctagonProperty(new SimpleOctagon(afac.top((OctagonDim(dim).toDBMDim))))(rext, okt, box)
-      override def bottom(dim : Int): Property = new OctagonProperty(new BottomOctagon(OctagonDim(dim)))(rext, okt, box)
+      override def top(dim : Int) : Property = new OctagonProperty(new SimpleOctagon(factory.top((OctagonDim(dim).toDBMDim))))(ifield, okt, box)
+      override def bottom(dim : Int): Property = new OctagonProperty(new BottomOctagon(OctagonDim(dim)))(ifield, okt, box)
     }
 
     val simpleOctDomain = new SimpleOctagonDomain(boxDomain)

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/BisimulationOctagonSpecification.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/BisimulationOctagonSpecification.scala
@@ -33,17 +33,14 @@ import it.unich.jandom.utils.numberext.RationalExt
 
 class BisimulationOctagonSpecification extends PropSpec with PropertyChecks {
   import it.unich.jandom.domains.numerical.Utils.Ints._
-  implicit val boxDomain : BoxRationalDomain = BoxRationalDomain()
+  val boxDomain : BoxRationalDomain = BoxRationalDomain()
 
-  class SimpleOctagonDomain(boxDomain : BoxGenericDomain[RationalExt]) extends OctagonDomain(boxDomain) {
-    implicit val okt : OctagonDomain = this
-    override def top(dim : Int) : Property = new OctagonProperty(new SimpleOctagon(factory.top((OctagonDim(dim).toDBMDim))))(ifield, okt, box)
-    override def bottom(dim : Int): Property = new OctagonProperty(new BottomOctagon(OctagonDim(dim)))(ifield, okt, box)
+  val simpleOctDomain = new OctagonDomain { // (boxDomain) {
+    type O = SimpleOctagon[RationalExt]
+    def makeTop(dim : Int) = new SimpleNonBottomOctagon(factory.top((OctagonDim(dim).toDBMDim)))
+    def makeBottom(dim: Int) = new SimpleBottomOctagon(OctagonDim(dim))
   }
-
-  val simpleOctDomain = new SimpleOctagonDomain(boxDomain)
   val octDomain = OctagonDomain()
-
 
   property("Weak oct-box bisimilarity: oct-T.{ some ops }.toBox <= oct-T.toBox{ some ops }") {
     forAll(GenTinyPosInt.suchThat(_ > 1)) {
@@ -74,15 +71,13 @@ package octagon.optimized {
 
   class BisimulationOptimizedOctagonSpecification extends PropSpec with PropertyChecks {
     import it.unich.jandom.domains.numerical.Utils.Ints._
-    implicit val boxDomain : BoxRationalDomain = BoxRationalDomain()
+    val boxDomain : BoxRationalDomain = BoxRationalDomain()
 
-    class SimpleOctagonDomain(boxDomain : BoxGenericDomain[RationalExt]) extends OctagonDomain(boxDomain) {
-      implicit val okt : OctagonDomain = this
-      override def top(dim : Int) : Property = new OctagonProperty(new SimpleOctagon(factory.top((OctagonDim(dim).toDBMDim))))(ifield, okt, box)
-      override def bottom(dim : Int): Property = new OctagonProperty(new BottomOctagon(OctagonDim(dim)))(ifield, okt, box)
+    val simpleOctDomain = new OctagonDomain { // (boxDomain) {
+      type O = SimpleOctagon[RationalExt]
+      def makeTop(dim : Int) = new SimpleNonBottomOctagon(factory.top((OctagonDim(dim).toDBMDim)))
+      def makeBottom(dim: Int) = new SimpleBottomOctagon(OctagonDim(dim))
     }
-
-    val simpleOctDomain = new SimpleOctagonDomain(boxDomain)
     val octDomain = OctagonDomain()
 
 

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/DBMSpecification.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/DBMSpecification.scala
@@ -1,0 +1,123 @@
+/**
+  * Copyright 2018 Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of a
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.utils.dbm
+import scala.reflect.ClassTag
+import org.scalatest.PropSpec
+import org.scalatest.prop.PropertyChecks
+import it.unich.jandom.utils.numberext.RationalExt
+
+class DBMSpecification extends PropSpec with PropertyChecks {
+  // TODO: write real tests!
+  implicit val ifield = RationalExt
+  implicit val tag = implicitly[ClassTag[RationalExt]]
+  implicit val afac = new ArrayDBMFactory()(tag, ifield)
+  implicit val closure = new IncrementalMineFloydWarshall[RationalExt]()(ifield, afac)
+
+  property("Quick check that closure does not break a closed DBM") {
+    // TODO: Test it for real
+    val arr = Array(
+      Array(RationalExt.zero, RationalExt.PositiveInfinity),
+      Array(RationalExt.PositiveInfinity, RationalExt.zero))
+    val dbm = ArrayDBM(DBMDim(2), arr)
+    assert(closure.strongClosure(dbm).get == afac.markAsClosed(dbm))
+    val arr2 = Array(
+      Array(RationalExt.zero, RationalExt.zero),
+      Array(RationalExt.zero, RationalExt.zero))
+    val dbm2 = ArrayDBM(DBMDim(2), arr2)
+    assert(closure.strongClosure(dbm2).get == afac.markAsClosed(dbm2))
+    val arr3 = Array(
+      Array(RationalExt.zero, RationalExt(1)),
+      Array(RationalExt(1), RationalExt.zero))
+    val dbm3 = ArrayDBM(DBMDim(2), arr3)
+    assert(closure.strongClosure(dbm3).get == afac.markAsClosed(dbm3))
+    val arr4 = Array(
+      Array(RationalExt(1), RationalExt(1)),
+      Array(RationalExt(1), RationalExt(1)))
+    val dbm4 = ArrayDBM(DBMDim(2), arr4)
+    assert(closure.strongClosure(dbm4).get != afac.markAsClosed(dbm4))
+    val arr5 = Array(
+      Array(RationalExt(0), RationalExt(-1)),
+      Array(RationalExt(1), RationalExt(0)))
+    val dbm5 = ArrayDBM(DBMDim(2), arr5)
+    assert(closure.strongClosure(dbm5).get == afac.markAsClosed(dbm5))
+  }
+
+
+  property ("Quick check that closure can tell a bottom when it sees it ") {
+    val a = afac.fromFun(DBMDim(4), (idx : DBMIdx) =>
+      if (idx.i == 2 & idx.j == 1 |idx.i == 1 & idx.j == 2)
+        -2
+      else if (idx.diagonal)
+        0
+      else
+        ifield.PositiveInfinity)
+
+    assert(closure.strongClosure(a) == None)
+  }
+
+
+  property ("Quick check for incrementalClosure") {
+
+    // TODO: write real tests that incrementalClosure(j0) yields the
+    // same as regular strong closure after changing the j0-th
+    // row/column on a closed DBM
+
+    val a = afac.fromFun(DBMDim(4), (idx : DBMIdx) =>
+      if (idx.i == 2 & idx.j == 1)
+        2
+      else if (idx.i == 1 & idx.j == 2)
+        1
+      else if (idx.i == 3 & idx.j == 4)
+        1
+      else if (idx.i == 4 & idx.j == 3)
+        -1
+      else if (idx.i == 5 & idx.j == 6)
+        0
+      else if (idx.i == 6 & idx.j == 5)
+        0
+      else if (idx.diagonal)
+        0
+      else
+        ifield.PositiveInfinity)
+
+    /*
+      0 -1
+      1  0
+           0  1
+          -1  0
+                 0  0
+                 0  0
+     */
+
+    val closed = closure.strongClosure(a)
+    assert(closed != None)
+    import it.unich.jandom.domains.numerical.octagon.Var
+    val v2 = Var(2)
+    val b = afac.fromFun(DBMDim(4), (idx : DBMIdx) =>
+      if (idx.i == v2.posForm.i | idx.j == v2.posForm.i)
+        a(idx) * 2
+      else
+        a(idx))
+
+
+    val reclosed = closure.strongClosure(b)
+    val incclosed = closure.incrementalClosure(v2)(b)
+    assert(reclosed == incclosed)
+  }
+}

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/LinearFormSuite.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/LinearFormSuite.scala
@@ -97,4 +97,27 @@ class LinearFormSuite extends FunSuite {
     assert(! lf5.isConstant)
     assert(! lf5.isZero)
   }
+
+  test ("Sets of equal lfs are subsets of each other") {
+    // This fails if hashCode is unsound
+    val o1cons = List(LinearForm(-2, 0, -1), LinearForm(2, 0, 1))
+    val o2cons = List(LinearForm(2, 0, 1), LinearForm(-2, 0, -1))
+    assert(!(o1cons sameElements o2cons))
+    val c1 = o1cons.toSet
+    val c2 = o2cons.toSet
+    assert(c1 subsetOf c2)
+    assert(c2 subsetOf c1)
+    assert(c1 == c2)
+  }
+
+  test ("Sets of different lfs are NOT subsets of each other") {
+    val o1cons = List(LinearForm(-2, 0, -1), LinearForm(2, 0, 1))
+    val o2cons = List(LinearForm(8, 0, 4), LinearForm(-4, 0, 2))
+    val c1 = o1cons.toSet
+    val c2 = o2cons.toSet
+    assert(!(o1cons sameElements o2cons))
+    assert(!(c1 subsetOf c2))
+    assert(!(c2 subsetOf c1))
+    assert(c1 != c2)
+  }
 }

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/OctagonSpecification.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/OctagonSpecification.scala
@@ -78,9 +78,9 @@ class OctagonSpecification extends PropSpec with PropertyChecks {
     }
   }
 
-  ///////////////////////////////////////////////////////
-  // Basic ordering properties of Octagon octagons
-  ///////////////////////////////////////////////////////
+  // ///////////////////////////////////////////////////////
+  // // Basic ordering properties of Octagon octagons
+  // ///////////////////////////////////////////////////////
 
 
   property("top.isTop") {
@@ -157,9 +157,9 @@ class OctagonSpecification extends PropSpec with PropertyChecks {
     }
   }
 
-  /////////////////////////////////////////
-  // Ordering/numerical properties
-  ////////////////////////////////////////
+  // /////////////////////////////////////////
+  // // Ordering/numerical properties
+  // ////////////////////////////////////////
 
   property ("Union of [C1,C1], [C2, C2] == [C1, C2] w/C1 <= C2") {
     forAll(Utils.Rationals.GenRationalInterval) {
@@ -249,8 +249,6 @@ class OctagonSpecification extends PropSpec with PropertyChecks {
       }
     }
   }
-
-  // // TODO: do more
 
   ///////////////////////////////////////////////////////
   // Numerical properties of OctagonProperty
@@ -401,11 +399,9 @@ class OctagonSpecification extends PropSpec with PropertyChecks {
           val _00m10 = zero.updated(j0 + 1, -1)
           val assigned  = top
             .linearAssignment(j0, LinearForm(c000 : _*))
-
           val assigned2 = assigned
             .linearAssignment(j0, LinearForm(_00m10 : _*))
             .linearAssignment(j0, LinearForm(_00m10 : _*))
-
           assert(assigned == assigned2)
           assert(assigned.constraints == assigned2.constraints)
         }
@@ -785,6 +781,8 @@ class OctagonSpecification extends PropSpec with PropertyChecks {
     }
   }
 
+  //////////////////////////////////
+
   property("T.{x <= c}.constraints == {x <= c}") {
     forAll (GenTinyPosInt.suchThat(_ > 0)){
       n : Int
@@ -1049,7 +1047,6 @@ class OctagonSpecification extends PropSpec with PropertyChecks {
   // Widening and narrowing
   ///////////////////////////////////////////////////////
 
-
   property ("forall X, Y : AbstractOctagon, (X widening Y) >= X, Y (condition 1 of 2 for soundness of widening)") {
     forAll(GenTinyPosInt.suchThat(_ > 1)) {
       n =>
@@ -1082,6 +1079,5 @@ class OctagonSpecification extends PropSpec with PropertyChecks {
 
 
   // TODO: check somehow that widening stabilizes
-
   // TODO: test narrowing
 }

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/OctagonSpecification.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/OctagonSpecification.scala
@@ -1,0 +1,155 @@
+/**
+  * Copyright 2018 Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of a
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.domains.numerical
+import it.unich.jandom.domains.numerical.octagon._
+import org.scalatest.PropSpec
+import org.scalatest.prop.PropertyChecks
+import it.unich.jandom.domains.numerical.Utils.Ints._
+
+
+class OctagonSpecification extends PropSpec with PropertyChecks {
+  implicit val boxDomain : BoxRationalDomain = BoxRationalDomain()
+  val octDomain = OctagonDomain()
+
+  ///////////////////////////////////////////////////////
+  // Sanity of to/fromBox
+  ///////////////////////////////////////////////////////
+
+  property("T_box to octagon to box == T_box") {
+    forAll(GenTinyPosInt.suchThat(_ > 1)) {
+      n => {
+        val top = boxDomain.top(n)
+        octDomain.fromBox(top).toBox == top
+      }
+    }
+  }
+
+  property("_|__box to octagon to box == _|__box") {
+    forAll(GenTinyPosInt.suchThat(_ > 1)) {
+      n => {
+        val bottom = boxDomain.bottom(n)
+        octDomain.fromBox(bottom).toBox == bottom
+      }
+    }
+  }
+
+  property("Some box to octagon to box == same box") {
+    forAll(GenTinyPosInt.suchThat(_ > 1)) {
+      n => {
+        import Utils.Halfplanes._
+        forAll(GenOctagonHalfplanesRat(n)) {
+          h =>
+          val box = octagonFromHalfPlanes(boxDomain)(n, h)
+          assert(octDomain.fromBox(box).toBox == box)
+        }
+      }
+    }
+  }
+
+  ///////////////////////////////////////////////////////
+  // Sanity of helpers
+  ///////////////////////////////////////////////////////
+
+  property("Var(i).posForm.toVar == Var(i), simm. neg") {
+    forAll(GenTinyPosInt.suchThat(_ > 0)) {
+      i =>
+      (Var(i).posForm).toVar == Var(i) &&
+      (Var(i).negForm).toVar == Var(i)
+    }
+  }
+
+  ///////////////////////////////////////////////////////
+  // Basic ordering properties of Octagon octagons
+  ///////////////////////////////////////////////////////
+
+
+  property("top.isTop") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      val top = octDomain.top(n)
+      assert (top.isTop)
+      assert(top.toBox == boxDomain.top(n))
+    }
+  }
+
+  property("bottom.isBottom") {
+    forAll (GenTinyPosInt){
+      n : Int
+      =>
+      val bottom = octDomain.bottom(n)
+      assert (bottom.isBottom)
+      assert(bottom.toBox == boxDomain.bottom(n))
+    }
+  }
+
+  property("T U T = T & T U _|_ = T") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      val top = octDomain.top(n)
+      val bottom = octDomain.bottom(n)
+      assert (top.union(top) == top)
+      assert (bottom.union(top) == top)
+    }
+  }
+
+  property("T /\\ _|_ = _|_ & _|_ /\\ _|_ = _|_") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      val top = octDomain.top(n)
+      val bottom = octDomain.bottom(n)
+      assert (bottom.intersection(bottom) == bottom)
+      assert (top.intersection(bottom) == bottom)
+    }
+  }
+
+  property("T U _|_ >= _|_ & T /\\ _|_ =< T") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      val top = octDomain.top(n)
+      val bottom = octDomain.bottom(n)
+      assert (bottom.union(top) > bottom)
+      assert (top.union(bottom) > bottom)
+      assert (bottom.intersection(top) < top)
+      assert (top.intersection(bottom) < top)
+      assert (bottom.union(top) >= bottom)
+      assert (top.union(bottom) >= bottom)
+      assert (bottom.intersection(top) <= top)
+      assert (top.intersection(bottom) <= top)
+    }
+  }
+
+  property("T != _|_, T !< T, _|_ !< _|_") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      val top = octDomain.top(n)
+      val bottom = octDomain.bottom(n)
+      assert (!(top == bottom))
+      assert (!(bottom == top))
+      assert (!(top > top))
+      assert (!(top < top))
+      assert (!(bottom < bottom))
+      assert (!(bottom > bottom))
+    }
+  }
+}

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/OctagonSpecification.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/OctagonSpecification.scala
@@ -18,8 +18,12 @@
 
 package it.unich.jandom.domains.numerical
 import it.unich.jandom.domains.numerical.octagon._
+import it.unich.jandom.utils.dbm._
 import org.scalatest.PropSpec
 import org.scalatest.prop.PropertyChecks
+import org.scalacheck.Gen
+import it.unich.jandom.utils.numberext.RationalExt
+import spire.math.Rational
 import it.unich.jandom.domains.numerical.Utils.Ints._
 
 
@@ -152,4 +156,932 @@ class OctagonSpecification extends PropSpec with PropertyChecks {
       assert (!(bottom > bottom))
     }
   }
+
+  /////////////////////////////////////////
+  // Ordering/numerical properties
+  ////////////////////////////////////////
+
+  property ("Union of [C1,C1], [C2, C2] == [C1, C2] w/C1 <= C2") {
+    forAll(Utils.Rationals.GenRationalInterval) {
+      (c : (Rational, Rational)) => {
+        val a = octDomain.top(1)
+        val b1 = a.linearAssignment(0, LinearForm.c(c._1))
+        val b2 = a.linearAssignment(0, LinearForm.c(c._2))
+        val union = b1 union b2
+        assert(c._1 <= c._2)
+        assert(union.toBox.isEmpty == false &
+         union.toBox.high.head == c._2 &
+         union.toBox.low.head == c._1)
+      }
+    }
+  }
+
+  property ("Intersection of [C1,C1], [C2, C2] == _|_ w/C1 < C2") {
+    forAll(Utils.Rationals.GenRationalInterval.suchThat(pair => pair._1 < pair._2)) {
+      (c : (Rational, Rational)) => {
+        val a = octDomain.top(1)
+        val b1 = a.linearAssignment(0, LinearForm.c(c._1))
+        val b2 = a.linearAssignment(0, LinearForm.c(c._2))
+        val intersection = b1 intersection b2
+        assert(c._1 <= c._2)
+        assert(intersection.isBottom == true &
+         intersection.toBox.isEmpty == true)
+      }
+    }
+  }
+
+  property ("[C1,C2] <= [C3<C1, C4>C2]") {
+    forAll(Utils.Rationals.GenRationalInterval) {
+      (c: (Rational, Rational)) =>
+    forAll(Utils.Rationals.GenRationalInterval) {
+          (d: (Rational, Rational)) => {
+            val c1 = c._1
+            val c2 = c._2
+            assert(c._1 <= c._2)
+            assert(d._1 <= d._2)
+            val posC = (d._2 - d._1) // is certainly non-neg
+            assert(posC >= 0)
+            val c3 = c1 - posC
+            val c4 = c2 + posC
+            assert(c3 <= c1 & c1 <= c4 & c4 >= c2)
+            val a = octDomain.top(1)
+            val b1 = a.linearAssignment(0, LinearForm.c(c1))
+            val b2 = a.linearAssignment(0, LinearForm.c(c2))
+            val b3 = a.linearAssignment(0, LinearForm.c(c3))
+            val b4 = a.linearAssignment(0, LinearForm.c(c4))
+            val i1 = b1 union b2 // i1 = [c1,c2]
+            val i2 = b3 union b4 // i2 = [c3,c4]
+            assert(i1 <= i2)
+          }
+        }
+    }
+  }
+
+  ///////////////////////////////////////////////////////
+  // Properties of Octagon.assignments
+  ///////////////////////////////////////////////////////
+
+  property(".assign_vj0_gets_c works as intended") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        _j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val j0 = _j0 + 1
+          import scala.reflect.ClassTag
+          implicit val rext = RationalExt
+          implicit val tag = implicitly[ClassTag[RationalExt]]
+          implicit val afac = new ArrayDBMFactory()(tag, rext)
+          implicit val bsc = new MineFloydWarshall[RationalExt]()(rext, afac)
+          def topoct = new optimized.PedanticOctagon(afac.top(OctagonDim(n).toDBMDim))
+          // val top = octDomain.top(n)
+          val updated = topoct.assign_vj0_gets_c(Var(j0), c)
+          assert(!updated.isBottom)
+          // Vi <= c is represented as Vi_pos - Vi_neg <= 2c, Mine' 2006 p 8
+          assert(updated.get_ineq_vi_minus_vj_leq_c(Var(j0).posForm, Var(j0).negForm).get == RationalExt(2 * c))
+          // Vi >= c is represented as Vi_neg - Vi_pos <= -2c, Mine' 2006 p 8
+          assert(updated.get_ineq_vi_minus_vj_leq_c(Var(j0).negForm, Var(j0).posForm).get == RationalExt(-2 * c))
+        }
+      }
+    }
+  }
+
+  // // TODO: do more
+
+  ///////////////////////////////////////////////////////
+  // Numerical properties of OctagonProperty
+  ///////////////////////////////////////////////////////
+
+  property("T.{x = x + c} == T, .constraints = emptyset") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val c001 = Array.fill(n + 1)(0).updated(j0 + 1, 1).updated(0, c)
+          val assigned  = top.linearAssignment(j0, LinearForm(c001 : _*))
+          val boxassigned  = boxDomain.top(n).linearAssignment(j0, LinearForm(c001 : _*))
+          assert(!assigned.isBottom)
+          assert (assigned <= top)
+          assert (assigned == top)
+          assert (assigned.constraints.size == 0)
+          assert(assigned.toBox <= boxassigned)
+        }
+      }
+    }
+  }
+
+  property("T.{x = -x} == T, .constraints = emptyset") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        val top = octDomain.top(n)
+        assert (top.constraints.size == 0)
+        val _0m10 = Array.fill(n + 1)(0).updated(j0 + 1, -1)
+        val assigned  = top.linearAssignment(j0, LinearForm(_0m10 : _*))
+        assert(!assigned.isBottom)
+        assert (assigned <= top)
+        assert (assigned == top)
+        assert (assigned.isTop)
+        assert (assigned.constraints.size == 0)
+      }
+    }
+  }
+
+  property("T.{x = c} != T") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val c000 = zero.updated(0, c)
+          val assigned  = top.linearAssignment(j0, LinearForm(c000 : _*))
+          assert(!assigned.isBottom)
+          assert (!assigned.isTop)
+          assert (assigned != top)
+          assert (assigned <= top)
+        }
+      }
+    }
+  }
+
+  property("T.{x = c}.constraints == Seq(x - c <= 0, -x + c <= 0)") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val c000 = zero.updated(0, c)
+          val assigned  = top.linearAssignment(j0, LinearForm(c000 : _*))
+          val constraints = assigned.constraints
+          assert(constraints.size == 2)
+          val c010 = zero.updated(j0 + 1, 1).updated(0, -c)   // v - c <= 0
+          val c0m10 = zero.updated(j0 + 1, -1).updated(0, c)  // -v + c <= 0
+          assert (constraints.contains(LinearForm(c010 : _*)))
+          assert (constraints.contains(LinearForm(c0m10 : _*)))
+        }
+      }
+    }
+  }
+
+  property("T.{x = c}.{x = -x} constraints == Seq(x - (-c) <= 0, -x + (-c) <= 0)") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val c000 = zero.updated(0, c)
+          val _00m10 = zero.updated(j0 + 1, -1)
+          val assigned  = top
+            .linearAssignment(j0, LinearForm(c000 : _*))
+            .linearAssignment(j0, LinearForm(_00m10 : _*))
+          val constraints = assigned.constraints
+          assert(constraints.size == 2)
+          val mc010 = zero.updated(j0 + 1, 1).updated(0, -(-c))
+          val mc0m10 = zero.updated(j0 + 1, -1).updated(0, (-c))
+          assert (constraints.contains(LinearForm(mc010 : _*)))
+          assert (constraints.contains(LinearForm(mc0m10 : _*)))
+        }
+      }
+    }
+  }
+
+  property("T.{x = c}.{x = -x}.{x = -x} == T.{x = c}") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val c000 = zero.updated(0, c)
+          val _00m10 = zero.updated(j0 + 1, -1)
+          val assigned  = top
+            .linearAssignment(j0, LinearForm(c000 : _*))
+
+          val assigned2 = assigned
+            .linearAssignment(j0, LinearForm(_00m10 : _*))
+            .linearAssignment(j0, LinearForm(_00m10 : _*))
+
+          assert(assigned == assigned2)
+          assert(assigned.constraints == assigned2.constraints)
+        }
+      }
+    }
+  }
+
+  property("T.{x = c}.{x = x + d} constraints == Seq(x - (c + d) <= 0, -x + (c + d) <= 0)") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          forAll (GenMediumInt){
+            d : Int
+            =>
+            val top = octDomain.top(n)
+            assert (top.constraints.size == 0)
+            val zero = Array.fill(n + 1)(0)
+            assert(zero.size == n + 1)
+            val c000 = zero.updated(0, c)
+            val d000 = zero.updated(j0 + 1, 1).updated(0, d)
+            val assigned  = top
+              .linearAssignment(j0, LinearForm(c000 : _*))
+              .linearAssignment(j0, LinearForm(d000 : _*))
+            val constraints = assigned.constraints
+            assert(constraints.size == 2)
+            val c010 = zero.updated(j0 + 1, 1).updated(0, -(c + d))  // v - (c + d) <= 0
+            val c0m10 = zero.updated(j0 + 1, -1).updated(0, (c + d)) // -v + (c + d) <= 0
+            assert (constraints.contains(LinearForm(c010 : _*)))
+            assert (constraints.contains(LinearForm(c0m10 : _*)))
+          }
+        }
+      }
+    }
+  }
+
+
+  property("T.{x = c}.(x = x + 1}, .constraints == {x <= c + 1, -x <= -c - 1}") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val c000 = zero.updated(0, c)
+          val assigned  = top.linearAssignment(j0, LinearForm(c000 : _*))
+          assert(!assigned.isBottom)
+          assert (assigned != top)
+          assert (assigned <= top)
+          assert (assigned.constraints.size == 2)
+          val c010 = zero.updated(j0 + 1, 1).updated(0, -c)  // v - c <= 0
+          val c0m10 = zero.updated(j0 + 1, -1).updated(0, c) // -v + c <= 0
+          assert (assigned.constraints.contains(LinearForm(c010 : _*)))
+          assert (assigned.constraints.contains(LinearForm(c0m10 : _*)))
+        }
+      }
+    }
+  }
+
+  property("T.{x <= c} != T") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val c001 = zero.updated(0, c).updated(j0 + 1, 1)
+          val assigned  = top.linearInequality(LinearForm(c001 : _*))
+          assert (assigned != top)
+          assert (assigned <= top)
+          assert (assigned.constraints.size == 1)
+        }
+      }
+    }
+  }
+
+  property("T.{x <- - c + 1}{x + c <= 0} == _|_") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val d = - c + 1
+          /*
+           * v <- - c + 1
+           * if (v + c <= 0) == (1 -c + c <= 0) then
+           *     // _|_
+           * end
+           */
+          val d001 = zero.updated(0, d).updated(j0 + 1, 1)
+          val c000 = zero.updated(0, c).updated(j0 + 1, 0)
+          val assigned  = top.linearAssignment(j0, LinearForm(c000 : _*))
+          val inequal  = assigned.linearInequality(LinearForm(d001 : _*))
+          assert (inequal != top)
+          assert (assigned <= top)
+          assert (inequal.isBottom)
+          assert (inequal == octDomain.bottom(n))
+        }
+      }
+    }
+  }
+
+  property("T.{x <- c}{x - c <= 0}.constraints { x - c <= 0, -x + c <= 0}") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val assigned  = top.linearAssignment(j0, LinearForm.c(c))
+          val mc001 = zero.updated(0, -c).updated(j0 + 1, 1) // x -c <= 0
+          val inequal  = assigned.linearInequality(LinearForm(mc001 : _*))
+          assert (inequal != top)
+          assert (inequal <= top)
+          assert (!inequal.isBottom)
+          assert (inequal != octDomain.bottom(n))
+          assert (inequal.constraints.size == 2)
+          assert (inequal.constraints.contains(LinearForm(zero.updated(j0 + 1, 1).updated(0, -c) : _*)))
+          assert (inequal.constraints.contains(LinearForm(zero.updated(j0 + 1, -1).updated(0, +c) : _*)))
+        }
+      }
+    }
+  }
+
+  property("T.{-x + c <= 0}{x - c <= 0}.constraints { x - c <= 0, -x + c <= 0}") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt.suchThat(_ != 0)){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val mc001 = zero.updated(0, -c).updated(j0 + 1, 1)  // x -c <= 0
+          val c00m1 = zero.updated(0,  c).updated(j0 + 1, -1) // -x + c <= 0
+          val inequal = top.linearInequality(LinearForm(mc001 : _*)).linearInequality(LinearForm(c00m1 : _*))
+          assert (inequal != top)
+          assert (inequal <= top)
+          assert (!inequal.isBottom)
+          assert (inequal != octDomain.bottom(n))
+          assert (inequal.constraints.size == 2)
+          assert (inequal.constraints.contains(LinearForm(mc001 : _*)))
+          assert (inequal.constraints.contains(LinearForm(c00m1 : _*)))
+        }
+      }
+    }
+  }
+
+
+  property("T.{x + y + c <= 0}.constraints = { x + y + c <= 0}") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (Gen.choose(0, n - 1)){
+          i0 : Int
+          =>
+          forAll (GenMediumInt.suchThat(_ != 0)){
+            c : Int
+            =>
+            val top = octDomain.top(n)
+            assert (top.constraints.size == 0)
+            val zero = Array.fill(n + 1)(0)
+            assert(zero.size == n + 1)
+            val c011 = zero.updated(0, -c).updated(j0 + 1, 1).updated(i0 + 1, 1)
+            val inequal = top.linearInequality(LinearForm(c011 : _*))
+            assert (inequal != top)
+            assert (inequal <= top)
+            assert (!inequal.isBottom)
+            assert (inequal != octDomain.bottom(n))
+            assert (inequal.constraints.size == 1)
+            assert (inequal.constraints.contains(LinearForm(c011 : _*)))
+          }
+        }
+      }
+    }
+  }
+
+
+  property("T.{x - y + c <= 0}.constraints = { x - y + c <= 0}") {
+    forAll (GenTinyPosInt.suchThat(_ > 1)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (Gen.choose(0, n - 1).suchThat(_ != j0)){
+          i0 : Int
+          =>
+          forAll (GenMediumInt.suchThat(_ != 0)){
+            c : Int
+            =>
+            val top = octDomain.top(n)
+            assert (top.constraints.size == 0)
+            val zero = Array.fill(n + 1)(0)
+            assert(zero.size == n + 1)
+            val c011 = zero.updated(0, -c).updated(j0 + 1, 1).updated(i0 + 1, -1)
+            val inequal = top.linearInequality(LinearForm(c011 : _*))
+            assert (inequal != top)
+            assert (inequal <= top)
+            assert (!inequal.isBottom)
+            assert (inequal != octDomain.bottom(n))
+            assert (inequal.constraints.size == 1)
+            assert (inequal.constraints.contains(LinearForm(c011 : _*)))
+          }
+        }
+      }
+    }
+  }
+
+  property("T.{-x - y + c <= 0}.constraints = {-x - y + c <= 0}") {
+    forAll (GenTinyPosInt.suchThat(_ > 1)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (Gen.choose(0, n - 1).suchThat(_ != j0)){
+          i0 : Int
+          =>
+          forAll (GenMediumInt.suchThat(_ != 0)){
+            c : Int
+            =>
+            val top = octDomain.top(n)
+            assert (top.constraints.size == 0)
+            val zero = Array.fill(n + 1)(0)
+            assert(zero.size == n + 1)
+            val c011 = zero.updated(0, +c).updated(j0 + 1, -1).updated(i0 + 1, -1)
+            val inequal = top.linearInequality(LinearForm(c011 : _*))
+            assert (inequal != top)
+            assert (inequal <= top)
+            assert (!inequal.isBottom)
+            assert (inequal != octDomain.bottom(n))
+            assert (inequal.constraints.size == 1)
+            assert (inequal.constraints.contains(LinearForm(c011 : _*)))
+          }
+        }
+      }
+    }
+  }
+
+  property("T.{x <- c}.{x - y + 0 <= 0} constraints include x <= y -> c <= y -> -y + c <= 0") {
+    forAll (GenTinyPosInt.suchThat(_ > 1)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (Gen.choose(0, n - 1).suchThat(_ != j0)){
+          i0 : Int
+          =>
+          forAll (GenMediumInt.suchThat(_ != 0)){
+            c : Int
+            =>
+            val top = octDomain.top(n)
+            assert (top.constraints.size == 0)
+            val zero = Array.fill(n + 1)(0)
+            assert(zero.size == n + 1)
+            val c000 = zero.updated(0, c)
+            val _001m1 = zero.updated(0, 0).updated(j0 + 1, 1).updated(i0 + 1, -1)
+            val inequal_1 = top.linearAssignment(j0, LinearForm(c000 : _*))
+            val inequal_3 = inequal_1.linearInequality(LinearForm(_001m1 : _*))
+            val c00m1 = zero.updated(0, c).updated(i0 + 1, -1)
+            assert (inequal_3.constraints.contains(LinearForm(c00m1 : _*)))
+          }
+        }
+      }
+    }
+  }
+
+
+  property("T.{x <- c}.{y <- x} implies  y = c, constraints include y - c <= 0, - y + c >= 0") {
+    forAll (GenTinyPosInt.suchThat(_ > 1)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (Gen.choose(0, n - 1).suchThat(_ != j0)){
+          i0 : Int
+          =>
+          forAll (GenMediumInt.suchThat(_ != 0)){
+            c : Int
+            =>
+            val top = octDomain.top(n)
+            assert (top.constraints.size == 0)
+            val zero = Array.fill(n + 1)(0)
+            assert(zero.size == n + 1)
+            val c000 = zero.updated(0, c)
+            val _0001 = zero.updated(0, 0).updated(j0 + 1, 1)
+            val inequal = top.
+              linearAssignment(j0, LinearForm(c000 : _*))
+              .linearAssignment(i0, LinearForm(_0001 : _*))
+            val c000m1 = zero.updated(0, c).updated(i0 + 1, -1)
+            val mc0001 = zero.updated(0, -c).updated(i0 + 1, 1)
+            assert (inequal != top)
+            assert (inequal <= top)
+            assert (!inequal.isBottom)
+            assert (inequal != octDomain.bottom(n))
+            assert (inequal.constraints.contains(LinearForm(c000m1 : _*)))
+            assert (inequal.constraints.contains(LinearForm(mc0001 : _*)))
+          }
+        }
+      }
+    }
+  }
+
+  property("T.{x <- c}{-x + c <= 0}{x - c <= 0}.constraints { x - c <= 0, -x + c <= 0}") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt.suchThat(_ != 0)){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val mc001 = zero.updated(0, -c).updated(j0 + 1, 1)  // x -c <= 0
+          val c00m1 = zero.updated(0,  c).updated(j0 + 1, -1) // -x + c <= 0
+          val inequal = top.linearAssignment(j0, LinearForm.c(c))
+            .linearInequality(LinearForm(mc001 : _*))
+            .linearInequality(LinearForm(c00m1 : _*))
+          assert (inequal != top)
+          assert (inequal <= top)
+          assert (!inequal.isBottom)
+          assert (inequal != octDomain.bottom(n))
+          assert (inequal.constraints.size == 2)
+          assert (inequal.constraints.contains(LinearForm(mc001 : _*)))
+          assert (inequal.constraints.contains(LinearForm(c00m1 : _*)))
+        }
+      }
+    }
+  }
+
+  property("T.{x <= c}.constraints == {x <= c}") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val c001 = zero.updated(0, c).updated(j0 + 1, 1) // c + 1 <= 0
+          val lf = LinearForm(c001 : _*)
+          val assigned  = top.linearInequality(lf)
+          assert (assigned != top)
+          assert (assigned <= top)
+          assert (assigned.constraints.size == 1)
+          assert(top.dimension == assigned.dimension & top.dimension == n)
+          assert (assigned.constraints.head.padded(n + 1) == lf)
+        }
+      }
+    }
+  }
+
+  property("T.{x - y <= c}.constraints == {x - y <= c}") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (Gen.choose(0, n - 1)){
+          i0 : Int
+          =>
+          forAll (GenMediumInt){
+            c : Int
+            =>
+            val top = octDomain.top(n)
+            assert (top.constraints.size == 0)
+            val zero = Array.fill(n + 1)(0)
+            assert(zero.size == n + 1)
+            val c001 = zero.updated(0, c).updated(j0 + 1, 1).updated(i0 + 1, - 1)
+            val lf = LinearForm(c001 : _*)
+            val assigned  = top.linearInequality(lf)
+            assert (assigned != top)
+            assert (assigned <= top)
+            assert (assigned.constraints.size == 1)
+            assert(top.dimension == assigned.dimension & top.dimension == n)
+            assert (assigned.constraints.head.padded(n + 1) == lf)
+          }
+        }
+      }
+    }
+  }
+
+  property("T.{x <- c}{x + c <= 0} == _|_") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val d = - c + 1
+          /*
+           * v <- - c + 1
+           * if (v + c <= 0) == (1 -c + c <= 0) then
+           *     // _|_
+           * end
+           */
+          val d001 = zero.updated(0, d).updated(j0 + 1, 1)
+          val c000 = zero.updated(0, c).updated(j0 + 1, 0)
+          val assigned  = top.linearAssignment(j0, LinearForm(c000 : _*))
+          val inequal  = assigned.linearInequality(LinearForm(d001 : _*))
+          assert (inequal != top)
+          assert (assigned <= top)
+          assert (inequal.isBottom)
+          assert (inequal == octDomain.bottom(n))
+        }
+      }
+    }
+  }
+
+  property("T.{x = c} <= T") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      val top = octDomain.top(n)
+      val bottom = octDomain.bottom(n)
+      assert (top.union(top) == top)
+      assert (bottom.union(top) == top)
+    }
+  }
+
+
+  property("T.{x <- c}{x <- -x} == T.{x <- -c}") {
+    forAll (GenTinyPosInt.suchThat(_ > 0)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val mc000 = zero.updated(0, -c)
+          val c000 = zero.updated(0, c)
+          val _00m1 = zero.updated(0, 0).updated(j0 + 1, -1)
+          val x_gets_c  = top.linearAssignment(j0, LinearForm(c000 : _*))
+          val x_gets_minus_c_then_gets_minus_x  =
+            top.linearAssignment(j0, LinearForm(mc000 : _*))
+              .linearAssignment(j0, LinearForm(_00m1 : _*))
+          assert (x_gets_c == x_gets_minus_c_then_gets_minus_x)
+          assert (x_gets_c <= x_gets_minus_c_then_gets_minus_x)
+          assert (x_gets_c >= x_gets_minus_c_then_gets_minus_x)
+        }
+      }
+    }
+  }
+
+  property("T.{x <- c}{y <- -x}{x <- -x} == T.{y <- -c}{x <- y}") {
+    forAll (GenTinyPosInt.suchThat(_ > 1)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (Gen.choose(0, n - 1).suchThat(_ != j0)){
+          i0 : Int
+          =>
+          forAll (GenMediumInt){
+            c : Int
+            =>
+            val top = octDomain.top(n)
+            assert (top.constraints.size == 0)
+            val zero = Array.fill(n + 1)(0)
+            assert(zero.size == n + 1)
+            val mc000 = zero.updated(0, -c)
+            val c000 = zero.updated(0, c)
+            val _00m1 = zero.updated(0, 0).updated(j0 + 1, -1)
+            val _010 = zero.updated(0, 0).updated(i0 + 1, 1)
+            val y_gets_c_then_x_gets_y  =
+              top.linearAssignment(i0, LinearForm(c000 : _*))//  i<- c
+                .linearAssignment(j0, LinearForm(_010 : _*)) //  j<-+i
+            val x_gets_minus_c_then_y_gets_minus_x_then_x_gets_minus_x  =
+              top.linearAssignment(j0, LinearForm(mc000 : _*)) // j <- -c
+                .linearAssignment(i0, LinearForm(_00m1 : _*))  // i <- -j
+                .linearAssignment(j0, LinearForm(_00m1 : _*))  // j <- -j
+            assert (y_gets_c_then_x_gets_y == x_gets_minus_c_then_y_gets_minus_x_then_x_gets_minus_x)
+            assert (y_gets_c_then_x_gets_y <= x_gets_minus_c_then_y_gets_minus_x_then_x_gets_minus_x)
+            assert (y_gets_c_then_x_gets_y >= x_gets_minus_c_then_y_gets_minus_x_then_x_gets_minus_x)
+          }
+        }
+      }
+    }
+  }
+
+  property("T.{x <- c} <= T.{x <= c + 1}{-x <= -c + 1}") {
+    forAll (GenTinyPosInt.suchThat(_ > 1)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          val bottom = octDomain.bottom(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val c000 = zero.updated(0, c)
+          val mcm0m10 = zero.updated(j0 + 1, 1).updated(0, - c - 1)  // x - c - 1 <= 0
+          val cm0m10 = zero.updated(j0 + 1, -1).updated(0, + c - 1)  // -x + c - 1 <= 0
+          val assigned = top.linearAssignment(j0, LinearForm(c000 : _*)) // j0 <- c
+          val inequal = top.linearInequality(LinearForm(mcm0m10 : _*))
+            .linearInequality(LinearForm(cm0m10 : _*))
+          assert (assigned <= inequal)
+          assert (assigned != inequal)
+          assert (!(assigned >= inequal)) // fails
+          assert (!(assigned >= top))
+          assert (bottom <= inequal)
+        }
+      }
+    }
+  }
+
+  property("T.{x <- c} !<= T.{x <= c - 1}{-x <= -c - 1} == _|_") {
+                                         // x >= c + 1
+    forAll (GenTinyPosInt.suchThat(_ > 1)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (GenMediumInt){
+          c : Int
+          =>
+          val top = octDomain.top(n)
+          val bottom = octDomain.bottom(n)
+          assert (top.constraints.size == 0)
+          val zero = Array.fill(n + 1)(0)
+          assert(zero.size == n + 1)
+          val c000 = zero.updated(0, c)
+          val mcm0m10 = zero.updated(j0 + 1, 1).updated(0, - c + 1)  // x - c + 1 <= 0
+          val cm0m10 = zero.updated(j0 + 1, -1).updated(0, + c + 1)  // -x + c + 1 <= 0
+          val assigned = top.linearAssignment(j0, LinearForm(c000 : _*)) // j0 <- c
+          val inequal = top.linearInequality(LinearForm(mcm0m10 : _*))
+            .linearInequality(LinearForm(cm0m10 : _*))
+          assert (!(assigned <= inequal))
+          // assert(false, inequal.o.asInstanceOf[LazyOctagon[_]].dbm)
+          assert (bottom == inequal)
+        }
+      }
+    }
+  }
+
+
+  property("T.{x <- c} !<= T.{y <- c} & T.{x <- c} !<= T.{y <- c} & T.{x <- c} != T.{y <- c}") {
+    forAll (GenTinyPosInt.suchThat(_ > 1)){
+      n : Int
+      =>
+      forAll (Gen.choose(0, n - 1)){
+        j0 : Int
+        =>
+        forAll (Gen.choose(0, n - 1).suchThat(_ != j0)) {
+          i0 : Int =>
+          forAll (GenMediumInt) {
+            c : Int
+            =>
+            val top = octDomain.top(n)
+            assert (top.constraints.size == 0)
+            val zero = Array.fill(n + 1)(0)
+            assert(zero.size == n + 1)
+            val c000 = zero.updated(0, c)
+            val ass1 = top.linearAssignment(j0, LinearForm(c000 : _*)) // j0 <- c
+            val ass2 = top.linearAssignment(i0, LinearForm(c000 : _*)) // i0 <- c
+            assert (ass1 != ass2)
+            assert (!(ass1 <= ass2))
+            assert (!(ass1 >= ass2))
+          }
+        }
+      }
+    }
+  }
+
+  ///////////////////////////////////////////////////////
+  // Widening and narrowing
+  ///////////////////////////////////////////////////////
+
+
+  property ("forall X, Y : AbstractOctagon, (X widening Y) >= X, Y (condition 1 of 2 for soundness of widening)") {
+    forAll(GenTinyPosInt.suchThat(_ > 1)) {
+      n =>
+      forAll(GenTinyPosInt.suchThat(_ > 1)) {
+        l =>
+        import Utils._
+        import OpSequences._
+        forAll(genSeq(n,l)) {
+          opSeq => {
+            forAll(GenTinyPosInt.suchThat(_ > 1)) {
+              l2 => {
+                import Utils._
+                import OpSequences._
+                forAll(genSeq(n,l2)) {
+                  opSeq2 => {
+                    val top = octDomain.top(n)
+                    val x = opSeq.foldLeft(top)((op, p) => applyOp(op)(p))
+                    val y = opSeq2.foldLeft(top)((op, p) => applyOp(op)(p))
+                    assert((x widening y) >= x)
+                    assert((x widening y) >= y)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+  // TODO: check somehow that widening stabilizes
+
+  // TODO: test narrowing
 }

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/Utils.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/Utils.scala
@@ -1,4 +1,4 @@
-package it.unich.jandom.domains.numerical.apron
+package it.unich.jandom.domains.numerical
 import it.unich.jandom.domains.numerical._
 
 import org.scalacheck.Arbitrary

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/Utils.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/Utils.scala
@@ -1,5 +1,4 @@
 package it.unich.jandom.domains.numerical
-import it.unich.jandom.domains.numerical._
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen.Choose
@@ -147,7 +146,6 @@ object Utils {
   }
 
   object OpSequences {
-    import Rationals.chooseRat
     import Rationals._
     def genExactLf(n : Int) : Gen[LinearForm] = {
       assert(n >= 2)
@@ -276,7 +274,6 @@ object Utils {
     }
 
     def octagonFromHalfPlanes(dom : NumericalDomain)(n : Int, h : Option[List[Halfplane]]) = {
-      import octagon._
       h match {
         case None => dom.bottom(n) //BottomOctagon(OctagonDim(n))
         case Some(l) =>
@@ -376,7 +373,6 @@ object Utils {
       )
     }
 
-    import Rationals.chooseRat
     import Rationals._
 
     def GenOctagonHalfplanesRat = (n : Int) => Gen.option(GenOctagonHalfplanes((n : Int) => Gen.containerOfN[List, Rational](n, GenRational),

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/octagon/SimpleOctagon.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/octagon/SimpleOctagon.scala
@@ -298,7 +298,7 @@ class SimpleOctagon[N <: IField[N]]
       case bot : BottomOctagon[N] => this
       case o   : SimpleOctagon[N] => stronglyClosed(
         this.m.combine((us, them) =>
-          if (us > them) us
+          if (us >= them) us
           else ∞
         )(o.m)
       )

--- a/core/src/test/scala/it/unich/jandom/domains/numerical/octagon/SimpleOctagon.scala
+++ b/core/src/test/scala/it/unich/jandom/domains/numerical/octagon/SimpleOctagon.scala
@@ -1,0 +1,351 @@
+/**
+  * Copyright 2018 Tobia Tesan
+  *
+  * This file is part of JANDOM: JVM-based Analyzer for Numerical DOMains
+  * JANDOM is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * JANDOM is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty ofa
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with JANDOM.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+package it.unich.jandom.domains.numerical.octagon.simple
+import it.unich.jandom.domains.numerical.octagon._
+import it.unich.jandom.utils.dbm._
+import it.unich.jandom.utils.numberext.IField
+import it.unich.jandom.utils.numberext.StaticIField
+
+import scala.language.implicitConversions
+
+/**
+  * A simple implementation of an octagonal representation that uses a
+  * DBM as its backend (basically, this _is_ a Mine'-style octagon,
+  * the artificial separation is for convenience of e.g. testing,
+  * stubbing).
+  *
+  * This is horrendously inefficient in that it maintains the
+  * invariant that the inner DBM is _always_ closed.
+  *
+  * On the other hand, it is easy to read, verify and compare with the
+  * paper, and serves as a ground truth for testing the more
+  * complicated implementation under optimized._, which, as the name
+  * suggests, tries to delay closure and opportunistically closes the
+  * matrix when needed.
+  *
+  * There are *two* ways in which the optimized implementation addresses this:
+  *
+  * 1. Keeps a non-closed inner matrix and performs the closure on request
+  *
+  * 2. Performs an incremental or noop closure when there is proof of
+  *    its sufficiency.
+  *
+  * THERE IS QUITE A LOT OF DUPLICATION between this and optimized._,
+  * this is on purpose, as adding the necessary levels of indirection
+  * through composition and inheritance would pollute this class to
+  * the point of defying its purpose as the simplest possible
+  * implementation.
+  */
+class SimpleOctagon[N <: IField[N]]
+  (val m : ClosedDBM[N])
+  (implicit ifield : StaticIField[N], cs : MineFloydWarshall[N])
+    extends Octagon[N] {
+
+  //////////////////////////////////////////////////////////////////
+  // Some sugar to make the following stuff read more like Mine 2006
+  //////////////////////////////////////////////////////////////////
+
+  val ∞ = ifield.PositiveInfinity
+  val _0 = ifield.zero
+
+  implicit def OctagonDimToDBMDim(d: OctagonDim) : DBMDim = d.toDBMDim
+  implicit def octftodbmf (f : OctIdx => N) : DBMIdx => N = (idx : DBMIdx) => f(OctIdx(idx))
+  implicit def octidxtodbmidx (idx : OctIdx) : DBMIdx = idx.idx
+  implicit def DBMtoOctagonDim(d : DBMDim) : OctagonDim = {
+    require(d.dbmDimToInt > 0 && (d.dbmDimToInt) % 2 == 0)
+    OctagonDim(d.dbmDimToInt / 2)
+  }
+  case class OctIdx(idx : DBMIdx) {
+    def i = SignedVarIdx(idx.i)
+    def j = SignedVarIdx(idx.j)
+  }
+
+  //////////////////////////////
+  // End sugar
+  //////////////////////////////
+
+
+  //////////////////////////////////////////////////////////////////
+  // Some utilities
+  //////////////////////////////////////////////////////////////////
+
+
+  protected def wrap(dbm : Option[ClosedDBM[N]]) : Octagon[N]  = dbm match {
+    case Some(dbm) => new SimpleOctagon[N](dbm)
+    case None => BottomOctagon[N](this.dimension)
+  }
+
+  def stronglyClosed (d : DBM[N]) = wrap(cs.strongClosure(d))
+  def stronglyClosed (n : DBMDim)(f : DBMIdx => N) = wrap(cs.stronglyClosed(n)(f))
+
+  // If the argument is closed the result is guaranteed to ble closed already (Mine' 2006 Fig. 26 p. 54)
+  def forget(f : Var) = stronglyClosed(m.dimension)(forget_f(m)(f))
+
+  def forget_f(m : DBM[N]) (f : Var) (idx : OctIdx) =
+      if (
+        idx.i != f.posForm &
+          idx.i != f.negForm &
+          idx.j != f.posForm &
+          idx.j != f.negForm)
+        m(idx) : N
+      else if (idx.i == idx.j & idx.j == f.posForm | idx.i == idx.j & idx.j == f.negForm)
+        _0 : N
+      else
+        ∞ : N
+
+  ////////////////////////////////////
+  // Begin octagon transfer functions
+  ////////////////////////////////////
+
+  /////////////////////////////
+  // Begin abstract tests
+  /////////////////////////////
+
+  def test_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] =
+    // Case 1. Mine' 2006 fig. 20 p. 42
+    // {{ Vj0 + c <= 0 ? }}
+    stronglyClosed(m.dimension)(
+      (idx : OctIdx) =>
+      if (idx.i == j0.negForm & idx.j == j0.posForm)
+        m(idx).min(-c._x_2)
+      else
+        m(idx))
+
+  def test_minus_vj0_plus_c_le_0 (j0 : Var, c : N) : Octagon[N] =
+    // Case 2. Mine' 2006 fig. 20 p. 42
+    // {{ -Vj0 + c <= 0 ? }}
+    // Note: this can be improved upon as
+    // 1. the argument of this op does not need to be closed;
+    // 2. the result can be closed via Inc*
+    // Same for the following ops
+    stronglyClosed(m.dimension)(
+      (idx : OctIdx) =>
+      if (idx.i == j0.posForm & idx.j == j0.negForm)
+        m(idx).min(-c._x_2)
+      else
+        m(idx))
+
+  def test_vj0_minus_vi0_plus_c_le_0(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+    // Case 3. Mine' 2006 fig. 20 p. 42
+    // {{ Vj0 - Vi0 + c <= 0 ? }}
+    require(j0 != i0) // see fig. 20
+    stronglyClosed(m.dimension)(
+        (idx : OctIdx) =>
+        if (idx.i == i0.posForm & idx.j == j0.posForm
+          | idx.i == j0.negForm & idx.j == i0.negForm
+        )
+          m(idx).min(-c)
+        else
+          m(idx))}
+
+  def test_vj0_plus_vi0_le_c(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+    // Case 4. Mine' 2006 fig. 20 p. 42
+    // {{ Vj0 + Vi0- + c <= 0 ? }}
+    require(j0 != i0) // see fig. 20
+    stronglyClosed(m.dimension)(
+        (idx : OctIdx) =>
+        if (idx.i == i0.negForm & idx.j == j0.posForm
+          | idx.i == j0.negForm & idx.j == i0.posForm
+        )
+          m(idx).min(-c)
+        else
+          m(idx))}
+
+  def test_minus_vj0_minus_vi0_plus_c_le_0(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+    // Case 5. Mine' 2006 fig. 20 p. 42
+    // {{ -Vj0 + Vi0- + c <= 0 ? }}
+    require(j0 != i0)
+    stronglyClosed(m.dimension)(
+      (idx : OctIdx) =>
+      if (idx.i == i0.posForm & idx.j == j0.negForm
+        | idx.i == j0.posForm & idx.j == i0.negForm
+      )
+        m(idx).min(-c)
+      else
+        m(idx))}
+
+  ///////////////////////
+  // End abstract tests
+  ///////////////////////
+
+
+  /////////////////////////////
+  // Begin abstract assignments
+  /////////////////////////////
+
+  def assign_vj0_gets_vi0(j0 : Var, i0 : Var) : Octagon[N] = assign_vj0_gets_vi0_plus_c(j0, i0, _0)
+
+  def assign_vj0_gets_c(j0 : Var, c : N) : Octagon[N] = {
+    // Case 1. Mine' 2006 fig. 15 p. 35
+    // {{ Vj0 <- c }}
+    stronglyClosed(m.dimension)(
+      (idx : OctIdx) => {
+        if (idx.i == j0.posForm & idx.j == j0.negForm)
+          (-c._x_2)
+        else if (idx.i == j0.negForm & idx.j == j0.posForm)
+          (c._x_2)
+        else
+          forget_f(m)(j0)(idx)
+      })}
+
+  def assign_vj0_gets_vj0_plus_c(j0 : Var, c : N) : Octagon[N] =
+    // Case 2. Mine' 2006 fig. 15 p. 35
+    // {{ Vj0 <- Vj0 + c }}
+    stronglyClosed(m.dimension)(
+      // Assignments Vj0 ← Vj0 + [a, b] and Vj0 ← −Vj0 + [a,
+      // b] do not require strongly closed matrix arguments but
+      // preserve the strong closure (Mine' 2006 p. 34)
+      (idx : OctIdx) =>
+      if (idx.i == j0.posForm & idx.j != j0.posForm & idx.j != j0.negForm ||
+        idx.j == j0.negForm & idx.i != j0.posForm & idx.i != j0.negForm)
+        m(idx) - c // Jandom doesn't support interval assignment, so [a,b] = [c,c]
+      else if
+        (idx.i != j0.posForm  & idx.i != j0.negForm & idx.j == j0.posForm ||
+          idx.j != j0.posForm  & idx.j != j0.negForm & idx.i == j0.negForm)
+        m(idx) + c
+      else if (idx.i == j0.posForm & idx.j == j0.negForm)
+        m(idx) - (c._x_2)
+      else if (idx.i == j0.negForm & idx.j == j0.posForm)
+        m(idx) + (c._x_2)
+      else
+        m(idx))
+
+
+  def assign_vj0_gets_vi0_plus_c(j0 : Var, i0 : Var, c : N) : Octagon[N] = {
+    // Case 3. Mine' 2006 fig. 15 p. 35
+    // {{ Vj0 <- Vi0 + c }}
+    require (j0 != i0)
+    stronglyClosed(m.dimension)(
+      (idx : OctIdx) =>
+      if (idx.i == j0.posForm & idx.j == i0.posForm
+        | idx.i == i0.negForm  & idx.j == j0.negForm)
+        -c
+      else
+        if (idx.i == i0.posForm & idx.j == j0.posForm
+          | idx.i == j0.negForm  & idx.j == i0.negForm)
+        c
+      else
+        forget_f(m)(j0)(idx))}
+
+  def assign_vj0_gets_minus_vj0(j0 : Var) : Octagon[N] = {
+    // Case 4. Mine' 2006 fig. 15 p. 35: {{ Vj0 <- -Vj0 }
+    stronglyClosed(m.dimension)(
+      // Assignments Vj0 ← Vj0 + [a, b] and Vj0 ← −Vj0 + [a,
+      // b] do not require strongly closed matrix arguments but
+      // preserve the strong closure (Mine' 2006 p. 34)
+      (idx : OctIdx) =>
+      if ((Seq(j0.posForm, j0.negForm) contains idx.i) &
+        !(Seq(j0.posForm, j0.negForm) contains idx.j))
+        m(idx.bari)
+      else
+        if (!(Seq(j0.posForm, j0.negForm) contains idx.i) &
+          (Seq(j0.posForm, j0.negForm) contains idx.j))
+        m(idx.barj)
+      else
+        if ((Seq(j0.posForm, j0.negForm) contains idx.i) &
+          (Seq(j0.posForm, j0.negForm) contains idx.j))
+        m(idx.barj.bari)
+      else {
+        assert (
+          !(Seq(j0.posForm, j0.negForm) contains idx.i) &
+            !(Seq(j0.posForm, j0.negForm) contains idx.j))
+        m(idx)})}
+
+  // Cases 5, 6, 7 are implemented in the Octagon trait
+
+  /////////////////////////////
+  // End abstract assignments
+  /////////////////////////////
+
+  def union(that : Octagon[N]) : Octagon[N] = {
+    that match {
+      case bot : BottomOctagon[N] => { assert (bot.dimension == this.dimension); this }
+      case o   : SimpleOctagon[N] => { assert (o.dimension == this.dimension);
+        stronglyClosed(this.m union o.m)
+      }
+      case _ => ??? // Not implemented
+    }
+  }
+
+  def intersection(that : Octagon[N]) : Octagon[N] = {
+    that match {
+      case bot : BottomOctagon[N] => { assert (bot.dimension == this.dimension); that }
+      case o   : SimpleOctagon[N] => { assert (o.dimension == this.dimension);
+        stronglyClosed(this.m intersection o.m)
+      }
+      case _ => ??? // Not implemented
+    }
+  }
+
+  def widening(that : Octagon[N]) : Octagon[N] =
+    that match {
+      case bot : BottomOctagon[N] => this
+      case o   : SimpleOctagon[N] => stronglyClosed(
+        this.m.combine((us, them) =>
+          if (us > them) us
+          else ∞
+        )(o.m)
+      )
+    }
+
+  def narrowing(that : Octagon[N]) : Octagon[N] =
+    that match {
+      case bot : BottomOctagon[N] => this
+      case o   : SimpleOctagon[N] => stronglyClosed(
+        this.m.combine((us, them) =>
+          if (us == ∞)
+            them
+          else
+            us
+        )(o.m)
+      )
+    }
+
+  /////////////////////////////////////////////
+
+  /**
+    * The indices *look* swapped here but are not.
+    *
+    * See Mine 2006 p.7, "the element at line i, column j, where 1 ≤ i
+    * ≤ n, 1 ≤ j ≤ n, denoted by mij equals c ∈ I if there is a
+    * constraint of the form Vj − Vi ≤ c ..."
+    */
+  def get_ineq_vi_minus_vj_leq_c(j : SignedVarIdx, i : SignedVarIdx) : Option[N] = Some(m(DBMIdx(i.i, j.i)))
+  def isEmpty = isBottom
+  def isBottom = false
+  def isTop = m.isTop
+  def dimension : OctagonDim = m.dimension
+
+  def tryCompareTo[B >: Octagon[N]](other: B)(implicit arg0: (B) => PartiallyOrdered[B]): Option[Int] =
+    other match {
+      case them : Octagon[N] =>
+        them match {
+          case _ : BottomOctagon[N] => Some(1)
+          case o : SimpleOctagon[N] =>
+            this.m.tryCompareTo(o.m)
+            // The following is only useful for making this comparable to "optimized" octagons
+            // for debugging purposes
+          case o : optimized.OptimizedOctagon[N] =>
+            o.closedDbm.fold(Some(1) : Option[Int])( // It's bottom
+              (m : ClosedDBM[N]) => this.m.tryCompareTo(m))
+          case _ => ??? // Not impl
+        }
+      case _ => None
+    }
+}

--- a/extended/build.sbt
+++ b/extended/build.sbt
@@ -6,6 +6,12 @@ unmanagedSourceDirectories in Compile ++= (pplJar.value map { _ => (sourceDirect
 
 unmanagedSourceDirectories in Test ++= (pplJar.value map { _ => (sourceDirectory in Test).value / "ppl" }).toSeq
 
+//*** Additional source directories for Apron
+
+unmanagedSourceDirectories in Compile ++= (apronJar.value map { _ => (sourceDirectory in Compile).value / "apron" }).toSeq
+
+unmanagedSourceDirectories in Test ++= (apronJar.value map { _ => (sourceDirectory in Test).value / "apron" }).toSeq
+
 //*** Assembly plugin
 
 test in assembly := { }

--- a/project/CustomKeys.scala
+++ b/project/CustomKeys.scala
@@ -2,6 +2,8 @@ import sbt._
 import Keys._
 
 object CustomKeys {
+  val apronJar = settingKey[Option[String]]("Location of the Apron library")
+  val gmpJar = settingKey[Option[String]]("Location of the GMP library")
   val pplJar = settingKey[Option[String]]("Location of the PPL library")
   val gitHeadCommitSHA = taskKey[String]("Current git commit SHA")
 }


### PR DESCRIPTION
We wrote a simple, high level, native version of the Octagon abstract domain (Mine' 2006, etc), which could possibly be extended with Fast Octagons (Singh 2015) in the future (see: `core/src/main/scala/it/unich/jandom/domains/numerical/octagon`).

Contextually, we also wrote a simple wrapper around Japron (see: `core/src/main/apron`).

We would love it if you wanted to consider it for merging.

Thanks.